### PR TITLE
Refactor LayoutManager so that it retains Buffer

### DIFF
--- a/Watt.xcodeproj/project.pbxproj
+++ b/Watt.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		6378677D2A1BE3FE0039960E /* LineNumberLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6378677C2A1BE3FE0039960E /* LineNumberLayer.swift */; };
 		637867812A1BEA960039960E /* InsertionPointLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637867802A1BEA960039960E /* InsertionPointLayer.swift */; };
 		637867832A1EC5B50039960E /* TextView+Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637867822A1EC5B50039960E /* TextView+Input.swift */; };
-		637867852A1EC6BB0039960E /* TextView+KeyBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637867842A1EC6BB0039960E /* TextView+KeyBindings.swift */; };
+		637867852A1EC6BB0039960E /* TextView+KeyBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637867842A1EC6BB0039960E /* TextView+KeyBinding.swift */; };
 		637867872A1FB2C50039960E /* NSRange+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637867862A1FB2C50039960E /* NSRange+Extensions.swift */; };
 		637BC1322A151F5F0089A34D /* Selection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BC1312A151F5F0089A34D /* Selection.swift */; };
 		637BC1422A156B620089A34D /* CGRect+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BC1412A156B620089A34D /* CGRect+Extensions.swift */; };
@@ -42,7 +42,7 @@
 		637BC1462A156B9B0089A34D /* CGSize+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BC1452A156B9B0089A34D /* CGSize+Extensions.swift */; };
 		63820B8D2A7164A500CC7458 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63820B8C2A7164A500CC7458 /* Collection+Extensions.swift */; };
 		63A618622A0C3AE200E70B0E /* Moby Dick.txt in Resources */ = {isa = PBXBuildFile; fileRef = 63A618612A0C3AE200E70B0E /* Moby Dick.txt */; };
-		63A618722A0EAF2000E70B0E /* WeakDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618712A0EAF2000E70B0E /* WeakDictionary.swift */; };
+		63A618722A0EAF2000E70B0E /* Weak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618712A0EAF2000E70B0E /* Weak.swift */; };
 		63A618742A0EC37700E70B0E /* LineNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618732A0EC37700E70B0E /* LineNumberView.swift */; };
 		63A618762A0FD61B00E70B0E /* TextView+LineNumbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618752A0FD61B00E70B0E /* TextView+LineNumbers.swift */; };
 		63B61A1229FD965800787BB9 /* WindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B61A1129FD965800787BB9 /* WindowController.swift */; };
@@ -117,7 +117,7 @@
 		6378677C2A1BE3FE0039960E /* LineNumberLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberLayer.swift; sourceTree = "<group>"; };
 		637867802A1BEA960039960E /* InsertionPointLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsertionPointLayer.swift; sourceTree = "<group>"; };
 		637867822A1EC5B50039960E /* TextView+Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextView+Input.swift"; sourceTree = "<group>"; };
-		637867842A1EC6BB0039960E /* TextView+KeyBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextView+KeyBindings.swift"; sourceTree = "<group>"; };
+		637867842A1EC6BB0039960E /* TextView+KeyBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextView+KeyBinding.swift"; sourceTree = "<group>"; };
 		637867862A1FB2C50039960E /* NSRange+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRange+Extensions.swift"; sourceTree = "<group>"; };
 		637BC1312A151F5F0089A34D /* Selection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Selection.swift; sourceTree = "<group>"; };
 		637BC1412A156B620089A34D /* CGRect+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGRect+Extensions.swift"; sourceTree = "<group>"; };
@@ -126,7 +126,7 @@
 		63820B8C2A7164A500CC7458 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
 		6396DEFD2AA9074D00B1D03B /* TreeSitterLanguages */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TreeSitterLanguages; sourceTree = "<group>"; };
 		63A618612A0C3AE200E70B0E /* Moby Dick.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Moby Dick.txt"; sourceTree = "<group>"; };
-		63A618712A0EAF2000E70B0E /* WeakDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakDictionary.swift; sourceTree = "<group>"; };
+		63A618712A0EAF2000E70B0E /* Weak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
 		63A618732A0EC37700E70B0E /* LineNumberView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineNumberView.swift; sourceTree = "<group>"; };
 		63A618752A0FD61B00E70B0E /* TextView+LineNumbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextView+LineNumbers.swift"; sourceTree = "<group>"; };
 		63B61A1129FD965800787BB9 /* WindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowController.swift; sourceTree = "<group>"; };
@@ -245,7 +245,7 @@
 				635B36AA2AAE1D94002FAE70 /* String+Extensions.swift */,
 				6346D1942A06EC2900CFB7EE /* TextContainer.swift */,
 				63B61A1529FDA2B800787BB9 /* TextView.swift */,
-				637867842A1EC6BB0039960E /* TextView+KeyBindings.swift */,
+				637867842A1EC6BB0039960E /* TextView+KeyBinding.swift */,
 				637867722A1BD1E10039960E /* TextView+Events.swift */,
 				637867822A1EC5B50039960E /* TextView+Input.swift */,
 				63B61A1F29FDAE0400787BB9 /* TextView+Layout.swift */,
@@ -256,7 +256,7 @@
 				635F815C2AA9E51900553E23 /* TreeSitter.swift */,
 				63B8B1752A9F890100F32C2C /* Utilities.swift */,
 				63B8B1772A9F8A3A00F32C2C /* UtilitiesTest.swift */,
-				63A618712A0EAF2000E70B0E /* WeakDictionary.swift */,
+				63A618712A0EAF2000E70B0E /* Weak.swift */,
 				63B61A1129FD965800787BB9 /* WindowController.swift */,
 				63A618612A0C3AE200E70B0E /* Moby Dick.txt */,
 				6372889229FD8E1A005B95E5 /* Assets.xcassets */,
@@ -456,7 +456,7 @@
 				63F0468C2A65D3F8001B8DA8 /* Rope.swift in Sources */,
 				637867732A1BD1E10039960E /* TextView+Events.swift in Sources */,
 				637867832A1EC5B50039960E /* TextView+Input.swift in Sources */,
-				63A618722A0EAF2000E70B0E /* WeakDictionary.swift in Sources */,
+				63A618722A0EAF2000E70B0E /* Weak.swift in Sources */,
 				6372888C29FD8E19005B95E5 /* AppDelegate.swift in Sources */,
 				63A618742A0EC37700E70B0E /* LineNumberView.swift in Sources */,
 				635B36AD2AAE4D7F002FAE70 /* Language.swift in Sources */,
@@ -472,7 +472,7 @@
 				63C907842A7847BD00E4D7C9 /* IntervalCache.swift in Sources */,
 				637867712A17F7460039960E /* TextView+Selection.swift in Sources */,
 				635B36AB2AAE1D94002FAE70 /* String+Extensions.swift in Sources */,
-				637867852A1EC6BB0039960E /* TextView+KeyBindings.swift in Sources */,
+				637867852A1EC6BB0039960E /* TextView+KeyBinding.swift in Sources */,
 				635B36AF2AAE5424002FAE70 /* Highlighter.swift in Sources */,
 				635B36B12AAFCD95002FAE70 /* Theme.swift in Sources */,
 				63B61A1629FDA2B800787BB9 /* TextView.swift in Sources */,

--- a/Watt/LayoutManager.swift
+++ b/Watt/LayoutManager.swift
@@ -160,7 +160,10 @@ class LayoutManager {
         }
 
         let line = line(containing: selection.lowerBound)
-        let frag = line.fragment(containing: selection.lowerBound, affinity: selection.affinity)!
+        guard let frag = line.fragment(containing: selection.lowerBound, affinity: selection.affinity) else {
+            debugFatalError("couldn't find line fragment")
+            return
+        }
 
         var rect: CGRect?
         var i = frag.range.lowerBound
@@ -410,12 +413,18 @@ class LayoutManager {
 
         // A line containing point.y should always have a fragment
         // that contains point.y.
-        let frag = line.fragment(forVerticalOffset: point.y)!
+        guard let frag = line.fragment(forVerticalOffset: point.y) else {
+            assertionFailure("no frag")
+            return (buffer.startIndex, buffer.isEmpty ? .upstream : .downstream)
+        }
 
         let pointInLine = convert(point, to: line)
         let pointInLineFragment = convert(pointInLine, to: frag)
 
-        let offsetInLine = frag.utf16OffsetInLine(for: pointInLineFragment)!
+        guard let offsetInLine = frag.utf16OffsetInLine(for: pointInLineFragment) else {
+            assertionFailure("no utf16OffsetInLine")
+            return (buffer.startIndex, buffer.isEmpty ? .upstream : .downstream)
+        }
 
         var pos = buffer.utf16.index(line.range.lowerBound, offsetBy: offsetInLine)
 
@@ -432,7 +441,10 @@ class LayoutManager {
     func position(forCharacterAt location: Buffer.Index, affinity: Selection.Affinity) -> CGPoint {
         let line = line(containing: location)
         // line should always have a fragment containing location
-        let frag = line.fragment(containing: location, affinity: affinity)!
+        guard let frag = line.fragment(containing: location, affinity: affinity) else {
+            assertionFailure("no frag")
+            return .zero
+        }
 
         let offsetInLine = buffer.utf16.distance(from: line.range.lowerBound, to: location)
         let fragPos = frag.positionForCharacter(atUTF16OffsetInLine: offsetInLine)

--- a/Watt/LayoutManager.swift
+++ b/Watt/LayoutManager.swift
@@ -43,7 +43,7 @@ class LayoutManager {
 
             heights = Heights(rope: buffer.text)
             lineCache = IntervalCache(upperBound: buffer.utf8.count)
-            invalidateLayout()
+            delegate?.didInvalidateLayout(for: self)
 
             let affinity: Selection.Affinity = buffer.isEmpty ? .upstream : .downstream
             let xOffset = position(forCharacterAt: buffer.startIndex, affinity: affinity).x

--- a/Watt/TextView+Input.swift
+++ b/Watt/TextView+Input.swift
@@ -69,9 +69,7 @@ extension TextView: NSTextInputClient {
     func unmarkText() {
         print("unmarkText")
 
-        if let selection = layoutManager.selection {
-            layoutManager.selection = selection.unmarked
-        }
+        layoutManager.selection = layoutManager.selection.unmarked
 
         // TODO: if we're the only one who calls unmarkText(), we can remove
         // these layout calls, because we already do layout in didInvalidateLayout(for layoutManager: LayoutManager)
@@ -81,15 +79,11 @@ extension TextView: NSTextInputClient {
     }
 
     func selectedRange() -> NSRange {
-        guard let range = layoutManager.selection?.range else {
-            return .notFound
-        }
-
-        return NSRange(range, in: buffer)
+        NSRange(layoutManager.selection.range, in: buffer)
     }
 
     func markedRange() -> NSRange {
-        guard let markedRange = layoutManager.selection?.markedRange else {
+        guard let markedRange = layoutManager.selection.markedRange else {
             return .notFound
         }
 
@@ -97,11 +91,7 @@ extension TextView: NSTextInputClient {
     }
 
     func hasMarkedText() -> Bool {
-        guard let selection = layoutManager.selection else {
-            return false
-        }
-
-        return selection.markedRange != nil
+        layoutManager.selection.markedRange != nil
     }
 
     func attributedSubstring(forProposedRange range: NSRange, actualRange: NSRangePointer?) -> NSAttributedString? {
@@ -154,11 +144,8 @@ extension TextView: NSTextInputClient {
         let viewPoint = convert(windowPoint, from: nil)
         let textContainerPoint = convertToTextContainer(viewPoint)
 
-        guard let characterIndex = layoutManager.location(interactingAt: textContainerPoint) else {
-            return NSNotFound
-        }
-
-        return buffer.utf16.distance(from: buffer.startIndex, to: characterIndex)
+        let location = layoutManager.location(interactingAt: textContainerPoint)
+        return buffer.utf16.distance(from: buffer.startIndex, to: location)
     }
 }
 
@@ -168,7 +155,7 @@ extension TextView {
             return Range(proposed, in: buffer)
         }
 
-        return layoutManager.selection?.markedRange ?? layoutManager.selection?.range
+        return layoutManager.selection.markedRange ?? layoutManager.selection.range
     }
 
     func discardMarkedText() {
@@ -181,7 +168,7 @@ extension TextView {
         // For mouse events, however, that doesn't seem to happen happen. Ditto for
         // things the text system doesn't know about, like selectAll(_:), etc. So
         // here we manually clear the marked text styles.
-        if let markedRange = layoutManager.selection?.markedRange {
+        if let markedRange = layoutManager.selection.markedRange {
             buffer.setAttributes(typingAttributes, in: markedRange)
         }
     }
@@ -204,7 +191,7 @@ extension TextView {
         let xOffset = layoutManager.position(forCharacterAt: head, affinity: affinity).x
         layoutManager.selection = Selection(head: head, affinity: affinity, xOffset: xOffset)
 
-        guard let (rect, _) = layoutManager.firstRect(forRange: layoutManager.selection!.range) else {
+        guard let (rect, _) = layoutManager.firstRect(forRange: layoutManager.selection.range) else {
             return
         }
 

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -16,10 +16,6 @@ extension TextView {
     // MARK: Movement
 
     override func moveForward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.isEmpty && selection.lowerBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -35,7 +31,7 @@ extension TextView {
             // If the selection ends at the end of a visual line, we want
             // affinity to be upstream so that when we press the right
             // arrow key, the caret doesn't end up on the next visual line.
-            let line = layoutManager.line(containing: selection.upperBound)!
+            let line = layoutManager.line(containing: selection.upperBound)
             let frag = line.fragment(containing: selection.upperBound, affinity: .upstream)!
 
             head = selection.upperBound
@@ -55,10 +51,6 @@ extension TextView {
     }
 
     override func moveBackward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.isEmpty && selection.lowerBound == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -100,13 +92,7 @@ extension TextView {
     // always corresponds to selection.lowerBound.
 
     override func moveUp(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.lowerBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.lowerBound)
         guard let frag = line.fragment(containing: selection.lowerBound, affinity: selection.affinity) else {
             return
         }
@@ -120,9 +106,7 @@ extension TextView {
                 y: frag.alignmentFrame.minY - 0.0001
             )
             let point = layoutManager.convert(pointInLine, from: line)
-            guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point) else {
-                return
-            }
+            let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point)
 
             layoutManager.selection = Selection(head: head, affinity: affinity, xOffset: selection.xOffset)
         }
@@ -133,13 +117,7 @@ extension TextView {
     }
 
     override func moveDown(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.upperBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.upperBound)
         guard let frag = line.fragment(containing: selection.upperBound, affinity: .upstream) else {
             return
         }
@@ -153,9 +131,7 @@ extension TextView {
                 y: frag.alignmentFrame.maxY
             )
             let point = layoutManager.convert(pointInLine, from: line)
-            guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point) else {
-                return
-            }
+            let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point)
 
             layoutManager.selection = Selection(head: head, affinity: affinity, xOffset: selection.xOffset)
         }
@@ -166,10 +142,6 @@ extension TextView {
     }
 
     override func moveWordForward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.isEmpty && selection.lowerBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -194,10 +166,6 @@ extension TextView {
     }
 
     override func moveWordBackward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.isEmpty && selection.lowerBound == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -220,13 +188,7 @@ extension TextView {
     }
 
     override func moveToBeginningOfLine(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.lowerBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.lowerBound)
         // Empty selections can have upstream affinity if they're at the end of a fragment,
         // and we need to know this to find the right one. 
         guard let frag = line.fragment(containing: selection.lowerBound, affinity: selection.isEmpty ? selection.affinity : .downstream) else {
@@ -248,13 +210,7 @@ extension TextView {
     }
 
     override func moveToEndOfLine(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.upperBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.upperBound)
         guard let frag = line.fragment(containing: selection.upperBound, affinity: selection.isEmpty ? selection.affinity : .upstream) else {
             return
         }
@@ -277,10 +233,6 @@ extension TextView {
     }
 
     override func moveToBeginningOfParagraph(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let start = buffer.lines.index(roundingDown: selection.lowerBound)
 
         if selection.isEmpty && start == selection.lowerBound {
@@ -299,10 +251,6 @@ extension TextView {
     }
 
     override func moveToEndOfParagraph(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.isEmpty && selection.upperBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -335,7 +283,7 @@ extension TextView {
     }
 
     override func moveToEndOfDocument(_ sender: Any?) {
-        if let selection = layoutManager.selection, selection.lowerBound == buffer.endIndex {
+        if selection.lowerBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
         }
@@ -349,7 +297,7 @@ extension TextView {
     }
 
     override func moveToBeginningOfDocument(_ sender: Any?) {
-        if let selection = layoutManager.selection, selection.lowerBound == buffer.startIndex {
+        if selection.lowerBound == buffer.startIndex {
             updateInsertionPointTimer()
             return
         }
@@ -364,10 +312,6 @@ extension TextView {
     }
 
     override func pageDown(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         // TODO: I don't think any of these calls to convertToTextContainer are correct.
         // We're using viewport.height down below, but the if there's a top or bottom
         // inset on the text container, the container will be shorter than the viewport.
@@ -380,9 +324,7 @@ extension TextView {
             y: point.y + viewport.height
         )
 
-        guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target) else {
-            return
-        }
+        let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target)
 
         layoutManager.selection = Selection(head: head, affinity: affinity, xOffset: selection.xOffset)
 
@@ -394,10 +336,6 @@ extension TextView {
     }
 
     override func pageUp(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let viewport = convertToTextContainer(visibleRect)
         let point = layoutManager.position(forCharacterAt: selection.lowerBound, affinity: selection.isEmpty ? selection.affinity : .upstream)
 
@@ -406,9 +344,7 @@ extension TextView {
             y: point.y - viewport.height
         )
 
-        guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target) else {
-            return
-        }
+        let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target)
 
         layoutManager.selection = Selection(head: head, affinity: affinity, xOffset: selection.xOffset)
 
@@ -420,10 +356,6 @@ extension TextView {
     }
 
     override func centerSelectionInVisibleArea(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let viewport = convertToTextContainer(visibleRect)
         let point = layoutManager.position(forCharacterAt: selection.lowerBound, affinity: .downstream)
 
@@ -437,10 +369,6 @@ extension TextView {
 
 
     override func moveBackwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.head == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -456,10 +384,6 @@ extension TextView {
     }
 
     override func moveForwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.head == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -476,10 +400,6 @@ extension TextView {
     }
 
     override func moveWordForwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.head == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -504,10 +424,6 @@ extension TextView {
     }
 
     override func moveWordBackwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.head == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -530,13 +446,7 @@ extension TextView {
     }
 
     override func moveUpAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.head) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.head)
         guard let frag = line.fragment(containing: selection.head, affinity: selection.affinity) else {
             return
         }
@@ -550,9 +460,7 @@ extension TextView {
                 y: frag.alignmentFrame.minY - 0.0001
             )
             let point = layoutManager.convert(pointInLine, from: line)
-            guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point) else {
-                return
-            }
+            let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point)
 
             layoutManager.selection = Selection(head: head, anchor: selection.anchor, affinity: affinity, xOffset: selection.xOffset)
         }
@@ -563,13 +471,7 @@ extension TextView {
     }
 
     override func moveDownAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.head) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.head)
         guard let frag = line.fragment(containing: selection.head, affinity: selection.affinity) else {
             return
         }
@@ -583,9 +485,7 @@ extension TextView {
                 y: frag.alignmentFrame.maxY
             )
             let point = layoutManager.convert(pointInLine, from: line)
-            guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point) else {
-                return
-            }
+            let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: point)
 
             layoutManager.selection = Selection(head: head, anchor: selection.anchor, affinity: affinity, xOffset: selection.xOffset)
         }
@@ -596,13 +496,7 @@ extension TextView {
     }
 
     override func moveToBeginningOfLineAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.lowerBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.lowerBound)
         guard let frag = line.fragment(containing: selection.lowerBound, affinity: selection.isEmpty ? selection.affinity : .downstream) else {
             return
         }
@@ -627,13 +521,7 @@ extension TextView {
     }
 
     override func moveToEndOfLineAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
-        guard let line = layoutManager.line(containing: selection.upperBound) else {
-            return
-        }
+        let line = layoutManager.line(containing: selection.upperBound)
         guard let frag = line.fragment(containing: selection.upperBound, affinity: selection.isEmpty ? selection.affinity : .upstream) else {
             return
         }
@@ -659,10 +547,6 @@ extension TextView {
     }
 
     override func moveToBeginningOfParagraphAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let start = buffer.lines.index(roundingDown: selection.lowerBound)
 
         if start == selection.lowerBound {
@@ -682,10 +566,6 @@ extension TextView {
     }
 
     override func moveToEndOfParagraphAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.upperBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -710,10 +590,6 @@ extension TextView {
     }
 
     override func moveToEndOfDocumentAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.upperBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -730,10 +606,6 @@ extension TextView {
     }
 
     override func moveToBeginningOfDocumentAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.lowerBound == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -751,10 +623,6 @@ extension TextView {
     }
 
     override func pageDownAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let viewport = convertToTextContainer(visibleRect)
         let point = layoutManager.position(forCharacterAt: selection.upperBound, affinity: selection.isEmpty ? selection.affinity : .upstream)
 
@@ -763,9 +631,7 @@ extension TextView {
             y: point.y + viewport.height
         )
 
-        guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target) else {
-            return
-        }
+        let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target)
 
         layoutManager.selection = Selection(head: head, anchor: selection.lowerBound, affinity: affinity, xOffset: selection.xOffset)
 
@@ -777,10 +643,6 @@ extension TextView {
     }
 
     override func pageUpAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         let viewport = convertToTextContainer(visibleRect)
         let point = layoutManager.position(forCharacterAt: selection.lowerBound, affinity: selection.isEmpty ? selection.affinity : .upstream)
 
@@ -789,9 +651,7 @@ extension TextView {
             y: point.y - viewport.height
         )
 
-        guard let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target) else {
-            return
-        }
+        let (head, affinity) = layoutManager.locationAndAffinity(interactingAt: target)
 
         layoutManager.selection = Selection(head: head, anchor: selection.upperBound, affinity: affinity, xOffset: selection.xOffset)
 
@@ -803,10 +663,6 @@ extension TextView {
     }
 
     override func moveParagraphForwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.upperBound == buffer.endIndex {
             updateInsertionPointTimer()
             return
@@ -831,10 +687,6 @@ extension TextView {
     }
 
     override func moveParagraphBackwardAndModifySelection(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if selection.lowerBound == buffer.startIndex {
             updateInsertionPointTimer()
             return
@@ -919,9 +771,7 @@ extension TextView {
 
     override func scrollLineUp(_ sender: Any?) {
         let viewport = convertToTextContainer(visibleRect)
-        guard let line = layoutManager.line(forVerticalOffset: viewport.minY - 0.0001) else {
-            return
-        }
+        let line = layoutManager.line(forVerticalOffset: viewport.minY - 0.0001)
         guard let frag = line.fragment(forVerticalOffset: viewport.minY - 0.0001) else {
             return
         }
@@ -939,9 +789,7 @@ extension TextView {
 
     override func scrollLineDown(_ sender: Any?) {
         let viewport = convertToTextContainer(visibleRect)
-        guard let line = layoutManager.line(forVerticalOffset: viewport.maxY) else {
-            return
-        }
+        let line = layoutManager.line(forVerticalOffset: viewport.maxY)
         guard let frag = line.fragment(forVerticalOffset: viewport.maxY) else {
             return
         }
@@ -981,10 +829,6 @@ extension TextView {
     // MARK: - Graphical element transposition
 
     override func transpose(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if buffer.count < 2 {
             return
         }
@@ -1033,10 +877,6 @@ extension TextView {
     // in and the next word.
     override func transposeWords(_ sender: Any?) {
         if buffer.isEmpty {
-            return
-        }
-
-        guard let selection = layoutManager.selection else {
             return
         }
 
@@ -1098,20 +938,12 @@ extension TextView {
     // MARK: - Insertion and indentation
 
     override func insertTab(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         replaceSubrange(selection.range, with: AttributedRope("\t", attributes: typingAttributes))
         unmarkText()
     }
 
 
     override func insertNewline(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         replaceSubrange(selection.range, with: AttributedRope("\n", attributes: typingAttributes))
         unmarkText()
     }
@@ -1127,10 +959,6 @@ extension TextView {
     // MARK: - Deletion
 
     override func deleteForward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if !selection.isEmpty {
             replaceSubrange(selection.range, with: "")
         } else if selection.lowerBound < buffer.endIndex {
@@ -1141,10 +969,6 @@ extension TextView {
     }
 
     override func deleteBackward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if !selection.isEmpty {
             replaceSubrange(selection.range, with: "")
         } else if selection.lowerBound > buffer.startIndex {
@@ -1155,10 +979,6 @@ extension TextView {
     }
 
     override func deleteWordForward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if !selection.isEmpty {
             replaceSubrange(selection.range, with: "")
         } else if selection.lowerBound < buffer.endIndex {
@@ -1178,10 +998,6 @@ extension TextView {
     }
 
     override func deleteWordBackward(_ sender: Any?) {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if !selection.isEmpty {
             replaceSubrange(selection.range, with: "")
         } else if selection.lowerBound > buffer.startIndex {

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -1,5 +1,5 @@
 //
-//  TextView+KeyBindings.swift
+//  TextView+KeyBinding.swift
 //  Watt
 //
 //  Created by David Albert on 5/24/23.

--- a/Watt/TextView+Selection.swift
+++ b/Watt/TextView+Selection.swift
@@ -10,9 +10,7 @@ import Cocoa
 extension TextView {
     func startSelection(at locationInView: CGPoint) {
         let point = convertToTextContainer(locationInView)
-        guard let (location, affinity) = layoutManager.locationAndAffinity(interactingAt: point) else {
-            return
-        }
+        let (location, affinity) = layoutManager.locationAndAffinity(interactingAt: point)
 
         let xOffset = layoutManager.position(forCharacterAt: location, affinity: affinity).x
         layoutManager.selection = Selection(head: location, affinity: affinity, xOffset: xOffset)
@@ -21,13 +19,7 @@ extension TextView {
 
     func extendSelection(to locationInView: CGPoint) {
         let point = convertToTextContainer(locationInView)
-        
-        guard let selection = layoutManager.selection else {
-            return
-        }
-        guard let location = layoutManager.location(interactingAt: point) else {
-            return
-        }
+        let location = layoutManager.location(interactingAt: point)
 
         // We always want the xOffset to be at the beginning of the selection, because
         // when we press up and down, we want the new caret to stay vertically aligned
@@ -42,10 +34,6 @@ extension TextView {
     }
 
     func setTypingAttributes() {
-        guard let selection = layoutManager.selection else {
-            return
-        }
-
         if buffer.isEmpty {
             typingAttributes = defaultAttributes
         } else if selection.lowerBound == buffer.endIndex {
@@ -95,10 +83,6 @@ extension TextView {
 
     func updateInsertionPointTimer() {
         insertionPointTimer?.invalidate()
-
-        guard let selection = layoutManager.selection else {
-            return
-        }
 
         guard shouldDrawInsertionPoint else {
             insertionPointLayer.isHidden = true

--- a/Watt/TextView.swift
+++ b/Watt/TextView.swift
@@ -94,22 +94,29 @@ class TextView: NSView, ClipViewDelegate {
     }
 
     var buffer: Buffer {
-        didSet {
-            // It would be more correct to merge defaultAttributes
-            // that aren't set on buffer, but we don't have a good
-            // way to do that.
+        get {
+            layoutManager.buffer
+        }
+        set {
+            layoutManager.buffer = newValue
+
+            // TODO: this is wrong. If there are two TextViews with the
+            // with the same buffer but differnt fonts, this will
+            // overwrite the font in both views.
+            //
+            // The solution is to merge the default attributes in only
+            // when they're needed in layoutManager(_:attributedRopeFor:).
             buffer.mergeAttributes(defaultAttributes)
 
-            oldValue.removeLayoutManager(layoutManager)
-            buffer.addLayoutManager(layoutManager)
-
             lineNumberView.buffer = buffer
-
-            layoutManager.invalidateLayout()
         }
     }
 
     let layoutManager: LayoutManager
+
+    var selection: Selection {
+        layoutManager.selection
+    }
 
     var lineNumberView: LineNumberView
 
@@ -152,7 +159,6 @@ class TextView: NSView, ClipViewDelegate {
     var previousVisibleRect: CGRect = .zero
 
     override init(frame frameRect: NSRect) {
-        buffer = Buffer()
         layoutManager = LayoutManager()
         lineNumberView = LineNumberView()
         super.init(frame: frameRect)
@@ -160,7 +166,6 @@ class TextView: NSView, ClipViewDelegate {
     }
 
     required init?(coder: NSCoder) {
-        buffer = Buffer()
         layoutManager = LayoutManager()
         lineNumberView = LineNumberView()
         super.init(coder: coder)

--- a/Watt/Weak.swift
+++ b/Watt/Weak.swift
@@ -74,3 +74,7 @@ struct WeakDictionary<Key: Hashable, Value: AnyObject> {
         storage.removeAll(keepingCapacity: true)
     }
 }
+
+struct WeakSet<Element> where Element: AnyObject {
+
+}


### PR DESCRIPTION
Buffer used to retain its LayoutManagers, but this made a lot of things simpler, especially the fact that `LayoutManager.selection`, `LayoutManager.line(forVerticalOffset:)` and `LayoutManager.line(containing:)` no longer have to be optional.