### PR TITLE
Use fixup to maintain Spans invariants

### DIFF
--- a/Watt/BTree.swift
+++ b/Watt/BTree.swift
@@ -1045,7 +1045,7 @@ extension NodeProtocol {
         mergeUndersizedChildren()
         updateNonLeafMetadata()
 
-        #if DEBUG
+        #if CHECK_INVARIANTS
         checkInvariants()
         #endif
     }
@@ -1085,7 +1085,7 @@ extension NodeProtocol {
 
         _ = helper(position, &self)
 
-        #if DEBUG
+        #if CHECK_INVARIANTS
         checkInvariants()
         #endif
     }
@@ -1133,7 +1133,7 @@ extension NodeProtocol {
         }
     }
 
-    #if DEBUG
+    #if CHECK_INVARIANTS
     func checkInvariants() {
         func helper<N>(_ n: N, isRoot: Bool) where N: NodeProtocol<Summary> {
             if isRoot {
@@ -1353,7 +1353,7 @@ struct BTreeBuilder<Tree> where Tree: BTree {
     }
 
     private mutating func push(_ node: PartialTree) {
-        #if DEBUG
+        #if CHECK_INVARIANTS
         defer { checkInvariants() }
         #endif
         var n = node
@@ -1535,7 +1535,7 @@ struct BTreeBuilder<Tree> where Tree: BTree {
         skipFixup = false
     }
 
-    #if DEBUG
+    #if CHECK_INVARIANTS
     func checkInvariants() {
         for nodes in stack {
             assert(!nodes.isEmpty)

--- a/Watt/BTree.swift
+++ b/Watt/BTree.swift
@@ -990,9 +990,9 @@ extension NodeProtocol {
             left.storage.mutationCount &+= 1
             defer { left.updateNonLeafMetadata() }
 
-            var (offset, done) = mutateChildren(pos, left.count, &left.children)
+            var (offset, more) = mutateChildren(pos, left.count, &left.children)
 
-            if done {
+            if !more {
                 return false
             }
 
@@ -1006,8 +1006,8 @@ extension NodeProtocol {
             }
 
             // handle the rest of the pairs
-            (_, done) = mutateChildren(pos - offset, right.count, &right.children)
-            return done
+            (_, more) = mutateChildren(pos - offset, right.count, &right.children)
+            return more
         }
 
         func mutateChildren(_ pos: Int, _ count: Int, _ children: inout [BTreeNode<Summary>]) -> (Int, Bool) {
@@ -1033,7 +1033,7 @@ extension NodeProtocol {
             }
 
             children = mutated
-            return (offset, done)
+            return (offset, !done)
         }
 
         ensureUnique()


### PR DESCRIPTION
The invariant: all equal adjacent spans are merged.

Doing this included changing BTreeLeaf's fixup interface so that instead two fixup methods (withPrevious, and withNext), we now have a single fixup(withNext:) method that can also mutate the next leaf.