### PR TITLE
First release of StandardKeyBindingResponder + other updates

### DIFF
--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
@@ -463,7 +463,7 @@ extension SelectionNavigator {
 // MARK: - Deletion
 
 extension SelectionNavigator {
-    public static func replacementDecomposingPreviousCharacter(for selection: Selection, dataSource: DataSource) -> (Range<Selection.Index>, String) {
+    public static func replacementForDeleteBackwardsByDecomposing(_ selection: Selection, dataSource: DataSource) -> (Range<Selection.Index>, String) {
         if selection.isRange {
             return (selection.range, "")
         }

--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
@@ -463,6 +463,29 @@ extension SelectionNavigator {
 // MARK: - Deletion
 
 extension SelectionNavigator {
+    public static func replacementDecomposingPreviousCharacter(for selection: Selection, dataSource: DataSource) -> (Range<Selection.Index>, String) {
+        if selection.isRange {
+            return (selection.range, "")
+        }
+
+        if selection.head == dataSource.startIndex {
+            return (selection.head..<selection.head, "")
+        }
+
+        let end = selection.head
+        let start = dataSource.index(before: end)
+        
+        var s = String(dataSource[start]).decomposedStringWithCanonicalMapping
+        s.unicodeScalars.removeLast()
+
+        // If we left a trailing Zero Width Joiner, remove that too.
+        if s.unicodeScalars.last == "\u{200d}" {
+            s.unicodeScalars.removeLast()
+        }
+
+        return (start..<end, s)
+    }
+
     public static func rangeToDelete(for selection: Selection, movement: Movement, dataSource: DataSource) -> Range<Selection.Index> {
         if selection.isRange {
             return selection.range

--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/SelectionNavigator.swift
@@ -152,7 +152,7 @@ extension NavigableSelection {
 }
 
 
-public struct SelectionNavigator<Selection, DataSource> where Selection: NavigableSelection, DataSource: SelectionNavigationDataSource, Selection.Index == DataSource.Index {
+public struct SelectionNavigator<Selection, DataSource> where Selection: NavigableSelection, DataSource: TextLayoutDataSource, Selection.Index == DataSource.Index {
     public let selection: Selection
 
     public init(_ selection: Selection) {
@@ -463,6 +463,9 @@ extension SelectionNavigator {
 // MARK: - Deletion
 
 extension SelectionNavigator {
+    // TODO: I don't love having this method be separate from rangeToDelete(for:movement:dataSource:), but
+    // rangeToDelete would have to return "" in all cases besides decomposition, and decomposition is only
+    // allowed when deleting backwards. I wonder if there's a better way.
     public static func replacementForDeleteBackwardsByDecomposing(_ selection: Selection, dataSource: DataSource) -> (Range<Selection.Index>, String) {
         if selection.isRange {
             return (selection.range, "")

--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/TextContentDataSource.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/TextContentDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  DocumentContentDataSource.swift
+//  TextContentDataSource.swift
 //
 //
 //  Created by David Albert on 11/15/23.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol DocumentContentDataSource {
+public protocol TextContentDataSource {
     associatedtype Index: Comparable
 
     var documentRange: Range<Index> { get }
@@ -26,7 +26,7 @@ public protocol DocumentContentDataSource {
 
 // MARK: - Default implementations
 
-public extension DocumentContentDataSource {
+public extension TextContentDataSource {
     func index(ofParagraphBoundaryBefore i: Index) -> Index {
         precondition(i > startIndex)
 
@@ -60,7 +60,7 @@ public extension DocumentContentDataSource {
 
 // MARK: - Internal helpers
 
-extension DocumentContentDataSource {
+extension TextContentDataSource {
     var isEmpty: Bool {
         documentRange.isEmpty
     }

--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/TextLayoutDataSource.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/TextLayoutDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  SelectionNavigationDataSource.swift
+//  TextLayoutDataSource.swift
 //
 //
 //  Created by David Albert on 11/8/23.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol SelectionNavigationDataSource: DocumentContentDataSource {
+public protocol TextLayoutDataSource: TextContentDataSource {
     func lineFragmentRange(containing index: Index) -> Range<Index>
     func lineFragmentRange(for point: CGPoint) -> Range<Index>?
     func verticalOffset(forLineFragmentContaining index: Index) -> CGFloat
@@ -30,7 +30,7 @@ public protocol SelectionNavigationDataSource: DocumentContentDataSource {
 
 
 // MARK: - Internal helpers
-extension SelectionNavigationDataSource {
+extension TextLayoutDataSource {
     func range(for granularity: Granularity, enclosing i: Index) -> Range<Index> {
         if isEmpty {
             return startIndex..<startIndex

--- a/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/Transposer.swift
+++ b/StandardKeyBindingResponder/Sources/StandardKeyBindingResponder/Transposer.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public enum Transposer<DataSource> where DataSource: DocumentContentDataSource {
+public enum Transposer<DataSource> where DataSource: TextContentDataSource {
     public typealias Index = DataSource.Index
 
     public static func indicesForTranspose(inSelectedRange range: Range<Index>, dataSource: DataSource) -> (Index, Index)? {

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/SelectionNavigatorTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/SelectionNavigatorTests.swift
@@ -1139,6 +1139,374 @@ final class SelectionNavigatorTests: XCTestCase {
     }
 
 
+    // MARK: - Deletion
+
+    func testDeleteBackward() {
+        let s = "abc def ghi"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "f"
+        var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .left, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 6))
+
+        // "def"
+        sel = TestSelection(anchor: s.index(at: 4), head: s.index(at: 7), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .left, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 7))
+    }
+
+    func testDeleteForward() {
+        let s = "abc def ghi"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "f"
+        var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .right, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 6)..<s.index(at: 7))
+
+        // "def"
+        sel = TestSelection(anchor: s.index(at: 4), head: s.index(at: 7), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .right, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 7))
+    }
+
+    func testDeleteWordForward() {
+        let s = "abc def ghi"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "e"
+        var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .wordRight, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 7))
+
+        // "e"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 6), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .wordRight, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 6))
+    }
+
+    func testDeleteWordBackward() {
+        let s = "abc def ghi"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "f"
+        var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .wordLeft, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 6))
+
+        // "e"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 6), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .wordLeft, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 6))
+    }
+
+    func testDeleteToBeginningOfLine() {
+        let s = "0123456789wrap"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 5))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 0), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 0))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 10), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 10))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 10), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 10)..<s.index(at: 10))
+
+        // caret at "p"
+        sel = TestSelection(caretAt: s.index(at: 13), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 10)..<s.index(at: 13))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 1), head: s.index(at: 4), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 1)..<s.index(at: 4))
+    }
+
+    func testDeleteToEndOfLine() {
+        let s = "0123456789wrap"
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 10))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 0), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 10))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 10), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 10)..<s.index(at: 10))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 10), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 10)..<s.index(at: 14))
+
+        // caret at "p"
+        sel = TestSelection(caretAt: s.index(at: 13), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 13)..<s.index(at: 14))
+
+        // caret after "p"
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 14)..<s.index(at: 14))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 1), head: s.index(at: 4), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 1)..<s.index(at: 4))
+
+
+        // don't delete trailing newline
+        let s2 = "foo\nbar"
+        let d2 = TestSelectionDataSource(string: s2, charsPerLine: 10)
+
+        // caret at second "o"
+        sel = TestSelection(caretAt: s2.index(at: 2), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d2)
+        XCTAssertEqual(r, s2.index(at: 2)..<s2.index(at: 3))
+
+        // caret at "\n"
+        sel = TestSelection(caretAt: s2.index(at: 3), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfLine, dataSource: d2)
+        XCTAssertEqual(r, s2.index(at: 3)..<s2.index(at: 3))
+    }
+
+    func testDeleteToBeginningOfParagraph() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 9))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 4), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 4))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 14))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 14))
+
+        // caret at "p"
+        sel = TestSelection(caretAt: s.index(at: 18), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 18))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+    }
+
+    func testDeleteToEndOfParagraph() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 9)..<s.index(at: 18))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 4), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 18))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 14)..<s.index(at: 18))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 14)..<s.index(at: 18))
+
+        // caret at "p" – we're at the end of a paragraph, so delete the trailing newline
+        sel = TestSelection(caretAt: s.index(at: 18), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 18)..<s.index(at: 19))
+
+        // caret at end
+        sel = TestSelection(caretAt: s.index(at: 22), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 22)..<s.index(at: 22))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfParagraph, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+    }
+
+    // deletion ranges for paragraphBackward/paragraphForward are the same as for beginningOfParagraph/endOfParagraph
+    func testDeleteParagraphBackward() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 9))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 4), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 4))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 14))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 14))
+
+        // caret at "p"
+        sel = TestSelection(caretAt: s.index(at: 18), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 18))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphBackward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+
+    }
+
+    func testDeleteParagraphForward() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 9)..<s.index(at: 18))
+
+        // caret at "0"
+        sel = TestSelection(caretAt: s.index(at: 4), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 4)..<s.index(at: 18))
+
+        // caret after "9" (upstream)
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 14)..<s.index(at: 18))
+
+        // caret at "w"
+        sel = TestSelection(caretAt: s.index(at: 14), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 14)..<s.index(at: 18))
+
+        // caret at "p" – we're at the end of a paragraph, so delete the trailing newline
+        sel = TestSelection(caretAt: s.index(at: 18), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 18)..<s.index(at: 19))
+
+        // caret at end
+        sel = TestSelection(caretAt: s.index(at: 22), affinity: .upstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 22)..<s.index(at: 22))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .paragraphForward, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+    }
+
+    func testDeleteBeginningOfDocument() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 9))
+
+        // caret at "f"
+        sel = TestSelection(caretAt: s.index(at: 0), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 0)..<s.index(at: 0))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .beginningOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+    }
+
+    func testDeleteEndOfDocument() {
+        let s = """
+        foo
+        0123456789wrap
+        bar
+        """
+        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+
+        // caret at "5"
+        var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
+        var r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 9)..<s.index(at: 22))
+
+        // caret at end
+        sel = TestSelection(caretAt: s.index(at: 22), affinity: .downstream, granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 22)..<s.index(at: 22))
+
+        // "123"
+        sel = TestSelection(anchor: s.index(at: 5), head: s.index(at: 8), granularity: .character)
+        r = SelectionNavigator.rangeToDelete(for: sel, movement: .endOfDocument, dataSource: d)
+        XCTAssertEqual(r, s.index(at: 5)..<s.index(at: 8))
+    }
+
     // MARK: - Mouse navigation
 
     func testClickingOnEmptyString() {

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/SelectionNavigatorTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/SelectionNavigatorTests.swift
@@ -13,7 +13,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveHorizontallyByCharacter() {
         let string = "ab\ncd\n"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
         s = moveAndAssert(s, direction: .right, caretAt: string.index(at: 1), affinity: .downstream, dataSource: d)
@@ -37,7 +37,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveRightToEndOfFrag() {
         let string = "a"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
 
@@ -46,7 +46,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveRightFromSelection() {
         let string = "foo bar baz"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "oo b"
         var s = TestSelection(anchor: string.index(at: 1), head: string.index(at: 5), granularity: .character)
@@ -81,7 +81,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveLeftFromSelection() {
         let string = "foo bar baz"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "oo b"
         var s = TestSelection(anchor: string.index(at: 1), head: string.index(at: 5), granularity: .character)
@@ -115,7 +115,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789abcdefghijwrap
         xyz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "1"
         var s = TestSelection(caretAt: string.index(at: 5), affinity: .downstream, granularity: .character)
@@ -149,7 +149,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveVerticallyWithEmptyLastLine() {
         let string = "abc\n"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // after "\n"
         var s = TestSelection(caretAt: string.endIndex, affinity: .upstream, granularity: .character)
@@ -171,7 +171,7 @@ final class SelectionNavigatorTests: XCTestCase {
         qrst
         uvwx
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // "f" through "k"
         var s = TestSelection(anchor: string.index(at: 6), head: string.index(at: 13), granularity: .character)
@@ -202,7 +202,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveHorizontallyByWord() {
         let string = "  hello, world; this is (a test) "
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
 
@@ -244,7 +244,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveByWordApostrophe() {
         let string = "foo bar's  '' baz"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
 
@@ -265,7 +265,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveRightWordFromSelection() {
         let string = "  hello, world; this is (a test) "
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "ello, w"
         var s = TestSelection(anchor: string.index(at: 3), head: string.index(at: 10), granularity: .character)
@@ -297,7 +297,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveLeftWordFromSelection() {
         let string = "  hello, world; this is (a test) "
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "lo, w"
         var s = TestSelection(anchor: string.index(at: 5), head: string.index(at: 10), granularity: .character)
@@ -329,7 +329,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveLineEmpty() {
         let string = ""
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.startIndex, affinity: .upstream, granularity: .character)
         s = moveAndAssert(s, direction: .beginningOfLine, caretAt: string.startIndex, affinity: .upstream, dataSource: d)
@@ -338,7 +338,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testMoveLineSingleFragments() {
         let string = "foo bar\nbaz qux\n"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // between "a" and "r"
         var s = TestSelection(caretAt: string.index(at: 6), affinity: .downstream, granularity: .character)
@@ -384,7 +384,7 @@ final class SelectionNavigatorTests: XCTestCase {
         let string = """
         0123456789abcdefghijwrap
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // between "0" and "1"
         var s = TestSelection(caretAt: string.index(at: 1), affinity: .downstream, granularity: .character)
@@ -436,7 +436,7 @@ final class SelectionNavigatorTests: XCTestCase {
         let string = """
         0123456789abcdefghijwrap
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // upstream between "9" and "a"
         var s = TestSelection(caretAt: string.index(at: 10), affinity: .upstream, granularity: .character)
@@ -462,7 +462,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789abcdefghijwrap
         bar
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "0123"
         var s = TestSelection(anchor: string.index(at: 0), head: string.index(at: 4), granularity: .character)
@@ -560,7 +560,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
         baz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // no-ops
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
@@ -629,7 +629,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
         baz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "0123"
         var s = TestSelection(anchor: string.index(at: 0), head: string.index(at: 4), granularity: .character)
@@ -687,7 +687,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
         baz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // no-ops
         var s = TestSelection(caretAt: string.index(at: 0), affinity: .downstream, granularity: .character)
@@ -709,7 +709,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
         baz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // select "ijwrap\nfoo\n\nb"
         var s = TestSelection(anchor: string.index(at: 18), head: string.index(at: 31), granularity: .character)
@@ -736,7 +736,7 @@ final class SelectionNavigatorTests: XCTestCase {
         stu
         vwx
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
 
         var s = TestSelection(caretAt: string.index(at: 1), affinity: .downstream, granularity: .character)
         s = moveAndAssert(s, direction: .pageDown, caret: "r", affinity: .downstream, dataSource: d)
@@ -768,7 +768,7 @@ final class SelectionNavigatorTests: XCTestCase {
         stu
         vwx
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
 
         // "abc" downstream
         var s = TestSelection(anchor: string.index(at: 0), head: string.index(at: 3), granularity: .character)
@@ -829,7 +829,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionByCharacter() {
         let string = "Hello, world!"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "!"
         var s = TestSelection(caretAt: string.index(at: 12), affinity: .downstream, granularity: .character)
@@ -854,7 +854,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789abcdefghijwrap
         xyz
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "b"
         var s = TestSelection(caretAt: string.index(at: 15), affinity: .downstream, granularity: .character)
@@ -875,7 +875,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionByWord() {
         let string = "foo; (bar) qux"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "a"
         var s = TestSelection(caretAt: string.index(at: 7), affinity: .downstream, granularity: .character)
@@ -893,7 +893,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionByLineEmpty() {
         let string = ""
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var s = TestSelection(caretAt: string.startIndex, affinity: .upstream, granularity: .character)
         s = extendAndAssert(s, direction: .endOfLine, caretAt: string.startIndex, affinity: .upstream, dataSource: d)
@@ -902,7 +902,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionByLineSoftWrap() {
         let string = "Hello, world!"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10) // Wraps after "r"
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10) // Wraps after "r"
 
         // caret at "o"
         var s = TestSelection(caretAt: string.index(at: 8), affinity: .downstream, granularity: .character)
@@ -929,7 +929,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionByLineHardWrap() {
         let string = "foo\nbar\nqux"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at first "a"
         var s = TestSelection(caretAt: string.index(at: 5), affinity: .downstream, granularity: .character)
@@ -952,7 +952,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        var d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        var d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "5"
         var s = TestSelection(caretAt: string.index(at: 9), affinity: .downstream, granularity: .character)
@@ -980,7 +980,7 @@ final class SelectionNavigatorTests: XCTestCase {
         foo
 
         """
-        d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "\n"
         s = TestSelection(caretAt: string.index(at: 4), affinity: .upstream, granularity: .character)
@@ -996,7 +996,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "5"
         var s = TestSelection(caretAt: string.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1031,7 +1031,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // caret at "5"
         var s = TestSelection(caretAt: string.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1068,7 +1068,7 @@ final class SelectionNavigatorTests: XCTestCase {
         stu
         vwx
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10, linesInViewport: 3)
 
         var s = TestSelection(caretAt: string.index(at: 1), affinity: .downstream, granularity: .character)
         s = extendAndAssert(s, direction: .pageDown, selected: "bc\ndef\n0123456789w", affinity: .downstream, dataSource: d)
@@ -1084,55 +1084,55 @@ final class SelectionNavigatorTests: XCTestCase {
         s = extendAndAssert(s, direction: .pageDown, selected: "bc\ndef\n0123456789w", affinity: .downstream, dataSource: d)
     }
 
-    func extendAndAssert(_ s: TestSelection, direction: Movement, caret c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func extendAndAssert(_ s: TestSelection, direction: Movement, caret c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extending: direction, dataSource: dataSource)
         assert(selection: s2, hasCaretBefore: c, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func extendAndAssert(_ s: TestSelection, direction: Movement, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func extendAndAssert(_ s: TestSelection, direction: Movement, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extending: direction, dataSource: dataSource)
         assert(selection: s2, hasRangeCovering: string, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func extendAndAssertNoop(_ s: TestSelection, direction: Movement, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func extendAndAssertNoop(_ s: TestSelection, direction: Movement, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extending: direction, dataSource: dataSource)
         XCTAssertEqual(s, s2, file: file, line: line)
         return s2
     }
 
-    func extendAndAssert(_ s: TestSelection, direction: Movement, caretAt caret: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func extendAndAssert(_ s: TestSelection, direction: Movement, caretAt caret: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extending: direction, dataSource: dataSource)
         assert(selection: s2, hasCaretAt: caret, affinity: affinity, granularity: granularity, file: file, line: line)
         return s2
     }
 
-    func moveAndAssert(_ s: TestSelection, direction: Movement, caret c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func moveAndAssert(_ s: TestSelection, direction: Movement, caret c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(moving: direction, dataSource: dataSource)
         assert(selection: s2, hasCaretBefore: c, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func moveAndAssert(_ s: TestSelection, direction: Movement, caretAfter c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func moveAndAssert(_ s: TestSelection, direction: Movement, caretAfter c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(moving: direction, dataSource: dataSource)
         assert(selection: s2, hasCaretAfter: c, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func moveAndAssert(_ s: TestSelection, direction: Movement, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func moveAndAssert(_ s: TestSelection, direction: Movement, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(moving: direction, dataSource: dataSource)
         assert(selection: s2, hasRangeCovering: string, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func moveAndAssertNoop(_ s: TestSelection, direction: Movement, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func moveAndAssertNoop(_ s: TestSelection, direction: Movement, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(moving: direction, dataSource: dataSource)
         XCTAssertEqual(s, s2, file: file, line: line)
         return s2
     }
 
-    func moveAndAssert(_ s: TestSelection, direction: Movement, caretAt caret: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func moveAndAssert(_ s: TestSelection, direction: Movement, caretAt caret: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(moving: direction, dataSource: dataSource)
         assert(selection: s2, hasCaretAt: caret, affinity: affinity, granularity: granularity, file: file, line: line)
         return s2
@@ -1143,7 +1143,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteBackward() {
         let s = "abc def ghi"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "f"
         var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
@@ -1158,7 +1158,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteBackwardWithDecomposition() {
         func t(_ s: String, _ selectedRange: Range<Int>, _ expectedRange: Range<Int>, _ expectedString: String, file: StaticString = #file, line: UInt = #line) {
-            let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+            let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
             let sel: TestSelection
             if selectedRange.isEmpty {
                 sel = TestSelection(caretAt: s.index(at: selectedRange.lowerBound), affinity: .downstream, granularity: .character)
@@ -1207,7 +1207,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteForward() {
         let s = "abc def ghi"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "f"
         var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
@@ -1222,7 +1222,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteWordForward() {
         let s = "abc def ghi"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "e"
         var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
@@ -1237,7 +1237,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteWordBackward() {
         let s = "abc def ghi"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "f"
         var sel = TestSelection(caretAt: s.index(at: 6), affinity: .downstream, granularity: .character)
@@ -1252,7 +1252,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteToBeginningOfLine() {
         let s = "0123456789wrap"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
@@ -1287,7 +1287,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDeleteToEndOfLine() {
         let s = "0123456789wrap"
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 5), affinity: .downstream, granularity: .character)
@@ -1327,7 +1327,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
         // don't delete trailing newline
         let s2 = "foo\nbar"
-        let d2 = TestSelectionDataSource(string: s2, charsPerLine: 10)
+        let d2 = TestTextLayoutDataSource(string: s2, charsPerLine: 10)
 
         // caret at second "o"
         sel = TestSelection(caretAt: s2.index(at: 2), affinity: .downstream, granularity: .character)
@@ -1346,7 +1346,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1385,7 +1385,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1430,7 +1430,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1470,7 +1470,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1514,7 +1514,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1538,7 +1538,7 @@ final class SelectionNavigatorTests: XCTestCase {
         0123456789wrap
         bar
         """
-        let d = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         // caret at "5"
         var sel = TestSelection(caretAt: s.index(at: 9), affinity: .downstream, granularity: .character)
@@ -1560,7 +1560,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testClickingOnEmptyString() {
         let string = ""
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         
         clickAndAssert(CGPoint(x: 0, y: -0.001), caretAt: string.index(at: 0), affinity: .upstream, dataSource: d)
         clickAndAssert(CGPoint(x: 100, y: -0.001), caretAt: string.index(at: 0), affinity: .upstream, dataSource: d)
@@ -1580,7 +1580,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testClickingOnNewline() {
         let string = "\n"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         clickAndAssert(CGPoint(x: 0, y: -0.001), caret: "\n", affinity: .downstream, dataSource: d)
         clickAndAssert(CGPoint(x: 100, y: -0.001), caret: "\n", affinity: .downstream, dataSource: d)
@@ -1610,7 +1610,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
 
         """
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // first fragment
 
@@ -1709,7 +1709,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDraggingEmptyString() {
         let string = ""
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // click
         var s = clickAndAssert(CGPoint(x: 0, y: 0), caretAt: string.startIndex, affinity: .upstream, dataSource: d)
@@ -1721,7 +1721,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testDraggingNewline() {
         let string = "\n"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // click
         var s = clickAndAssert(CGPoint(x: 0, y: 0), caret: "\n", affinity: .downstream, dataSource: d)
@@ -1737,7 +1737,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
         """
 
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // click at "5"
         var s = clickAndAssert(CGPoint(x: 40, y: 0), caret: "5", affinity: .downstream, dataSource: d)
@@ -1790,7 +1790,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendSelectionToEnclosingEmpty() {
         let string = ""
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         
         var s = TestSelection(caretAt: string.startIndex, affinity: .upstream, granularity: .character)
         s = SelectionNavigator(s).selection(for: .word, enclosing: CGPoint(x: 0, y: 0), dataSource: d)
@@ -1809,7 +1809,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
         """
 
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // before "0"
         var s = clickAndAssert(CGPoint(x: -1, y: 0), caret: "0", affinity: .downstream, dataSource: d)
@@ -1864,7 +1864,7 @@ final class SelectionNavigatorTests: XCTestCase {
 
     func testExtendingSelectionToWordApostrophe() {
         let string = "foo bar's baz’s 'qux' a’'b"
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // just before "bar's"
         var s = clickAndAssert(CGPoint(x: 31.999, y: 0), caret: "b", affinity: .downstream, dataSource: d)
@@ -1925,7 +1925,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
         """
 
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // at "b"
         var s = clickAndAssert(CGPoint(x: 32, y: 0), caret: "b", affinity: .downstream, dataSource: d)
@@ -1978,7 +1978,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
         """
 
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // at "r"
         var s = clickAndAssert(CGPoint(x: 4, y: 14), caret: "r", affinity: .downstream, dataSource: d)
@@ -1997,7 +1997,7 @@ final class SelectionNavigatorTests: XCTestCase {
         hello
         """
 
-        let d = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let d = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // at "r"
         var s = clickAndAssert(CGPoint(x: 4, y: 14), caret: "r", affinity: .downstream, dataSource: d)
@@ -2011,54 +2011,54 @@ final class SelectionNavigatorTests: XCTestCase {
     }
 
     @discardableResult
-    func clickAndAssert(_ point: CGPoint, caret: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func clickAndAssert(_ point: CGPoint, caret: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s: TestSelection = SelectionNavigator.selection(interactingAt: point, dataSource: dataSource)
         assert(selection: s, hasCaretBefore: caret, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s
     }
 
     @discardableResult
-    func clickAndAssert(_ point: CGPoint, caretAt: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func clickAndAssert(_ point: CGPoint, caretAt: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s: TestSelection = SelectionNavigator.selection(interactingAt: point, dataSource: dataSource)
         assert(selection: s, hasCaretAt: caretAt, affinity: affinity, granularity: granularity, file: file, line: line)
         return s
     }
     
     @discardableResult
-    func dragAndAssert(_ s: TestSelection, point: CGPoint, caret: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func dragAndAssert(_ s: TestSelection, point: CGPoint, caret: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extendingTo: point, dataSource: dataSource)
         assert(selection: s2, hasCaretBefore: caret, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
     @discardableResult
-    func dragAndAssert(_ s: TestSelection, point: CGPoint, caretAt: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func dragAndAssert(_ s: TestSelection, point: CGPoint, caretAt: String.Index, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extendingTo: point, dataSource: dataSource)
         assert(selection: s2, hasCaretAt: caretAt, affinity: affinity, granularity: granularity, file: file, line: line)
         return s2
     }
 
     @discardableResult
-    func dragAndAssert(_ s: TestSelection, point: CGPoint, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func dragAndAssert(_ s: TestSelection, point: CGPoint, selected string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity = .character, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(extendingTo: point, dataSource: dataSource)
         assert(selection: s2, hasRangeCovering: string, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func encloseAndAssert(_ s: TestSelection, enclosing granularity: TestSelection.Granularity, point: CGPoint, selected string: String, affinity: TestSelection.Affinity, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
+    func encloseAndAssert(_ s: TestSelection, enclosing granularity: TestSelection.Granularity, point: CGPoint, selected string: String, affinity: TestSelection.Affinity, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) -> TestSelection {
         let s2 = SelectionNavigator(s).selection(for: Granularity(granularity), enclosing: point, dataSource: dataSource)
         assert(selection: s2, hasRangeCovering: string, affinity: affinity, granularity: granularity, dataSource: dataSource, file: file, line: line)
         return s2
     }
 
-    func assert(selection: TestSelection, hasCaretBefore c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) {
+    func assert(selection: TestSelection, hasCaretBefore c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) {
         XCTAssert(selection.isCaret, "selection is not a caret", file: file, line: line)
         XCTAssertEqual(dataSource.string[selection.range.lowerBound], c, "caret is not at '\(c)'", file: file, line: line)
         XCTAssertEqual(affinity, selection.affinity, file: file, line: line)
         XCTAssertEqual(granularity, selection.granularity, file: file, line: line)
     }
 
-    func assert(selection: TestSelection, hasCaretAfter c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) {
+    func assert(selection: TestSelection, hasCaretAfter c: Character, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) {
         XCTAssert(selection.isCaret, "selection is not a caret", file: file, line: line)
         if selection.range.lowerBound == dataSource.string.endIndex {
             XCTFail("caret is not after '\(c)'", file: file, line: line)
@@ -2069,7 +2069,7 @@ final class SelectionNavigatorTests: XCTestCase {
         XCTAssertEqual(granularity, selection.granularity, file: file, line: line)
     }
 
-    func assert(selection: TestSelection, hasRangeCovering string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestSelectionDataSource, file: StaticString = #file, line: UInt = #line) {
+    func assert(selection: TestSelection, hasRangeCovering string: String, affinity: TestSelection.Affinity, granularity: TestSelection.Granularity, dataSource: TestTextLayoutDataSource, file: StaticString = #file, line: UInt = #line) {
         let range = selection.range
         XCTAssert(selection.isRange, "selection is not a range", file: file, line: line)
         XCTAssertEqual(String(dataSource.string[range]), string, "selection does not contain \"\(string)\"", file: file, line: line)

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/Support/TestTextContentDataSource.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/Support/TestTextContentDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  TestTextContentDataSource.swift
 //  
 //
 //  Created by David Albert on 12/6/23.
@@ -8,7 +8,7 @@
 import Foundation
 @testable import StandardKeyBindingResponder
 
-struct SimpleContentDataSource: DocumentContentDataSource {
+struct TestTextContentDataSource: TextContentDataSource {
     var s: String
 
     init(_ s: String) {
@@ -36,7 +36,7 @@ struct SimpleContentDataSource: DocumentContentDataSource {
     }
 }
 
-extension SimpleContentDataSource: ExpressibleByStringLiteral {
+extension TestTextContentDataSource: ExpressibleByStringLiteral {
     init(stringLiteral value: String) {
         self.s = value
     }

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/Support/TestTextLayoutDataSource.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/Support/TestTextLayoutDataSource.swift
@@ -1,5 +1,5 @@
 //
-//  TestSelectionDataSource.swift
+//  TestTextLayoutDataSource.swift
 //  
 //
 //  Created by David Albert on 11/9/23.
@@ -19,7 +19,7 @@ import StandardKeyBindingResponder
 // - Whitespace is treated just like normal characters. If you add
 //   a space after the end of a line fragment, no fancy wrapping
 //   happens. The next line fragment just starts with a space.
-struct TestSelectionDataSource {
+struct TestTextLayoutDataSource {
     let string: String
 
     // Number of visual characters in a line fragment. Does
@@ -47,7 +47,7 @@ struct TestSelectionDataSource {
     }
 }
 
-extension TestSelectionDataSource: SelectionNavigationDataSource {
+extension TestTextLayoutDataSource: TextLayoutDataSource {
     var characterCount: Int {
         string.count
     }
@@ -193,7 +193,7 @@ struct CaretOffset: Equatable {
     }
 }
 
-extension TestSelectionDataSource {
+extension TestTextLayoutDataSource {
     func carretOffsetsInLineFragment(containing index: String.Index) -> [CaretOffset] {
         var offsets: [CaretOffset] = []
         enumerateCaretOffsetsInLineFragment(containing: index) { offset, i, edge in

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TestSelectionTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TestSelectionTests.swift
@@ -1,5 +1,5 @@
 //
-//  SimpleSelectionTests.swift
+//  TestSelectionTests.swift
 //  
 //
 //  Created by David Albert on 11/9/23.
@@ -8,7 +8,7 @@
 import XCTest
 @testable import StandardKeyBindingResponder
 
-final class SimpleSelectionTests: XCTestCase {
+final class TestSelectionTests: XCTestCase {
     func testCreateCaret() {
         let string = "Hello, world!"
         let s = TestSelection(caretAt: string.index(at: 1), affinity: .upstream, granularity: .character)

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TestTextLayoutDataSourceTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TestTextLayoutDataSourceTests.swift
@@ -1,5 +1,5 @@
 //
-//  SimpleSelectionDataSourceTests.swift
+//  TestTextLayoutDataSourceTests.swift
 //
 //
 //  Created by David Albert on 11/8/23.
@@ -10,12 +10,12 @@ import XCTest
 // Sanity checks to make sure we can rely on SimpleSelectionDataSource
 // for use in the rest of our tests.
 
-final class SimpleSelectionDataSourceTests: XCTestCase {
+final class TestTextLayoutDataSourceTests: XCTestCase {
     // MARK: lineFragmentRange(containing:)
 
     func testLineFragmentRangesEmptyBuffer() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = dataSource.lineFragmentRange(containing: s.startIndex)
 
@@ -26,7 +26,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
         // 1 line, 5 line fragments, with the fifth fragment only holding 2 characters
         let charsPerFrag = 10
         let s = String(repeating: "a", count: charsPerFrag*4 + 2)
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: charsPerFrag)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: charsPerFrag)
 
         let start0 = s.index(s.startIndex, offsetBy: 0*charsPerFrag)
         let start1 = s.index(s.startIndex, offsetBy: 1*charsPerFrag)
@@ -54,7 +54,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
         // 1 line, 5 line fragments, with the fifth fragment only holding 2 characters
         let charsPerFrag = 10
         let string = String(repeating: "a", count: charsPerFrag*4 + 2)
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: charsPerFrag)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: charsPerFrag)
 
         let i0 = string.index(string.startIndex, offsetBy: 0*charsPerFrag + 1)
         let i1 = string.index(string.startIndex, offsetBy: 1*charsPerFrag + 1)
@@ -90,7 +90,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
         XCTAssertEqual(4, string.filter { $0 == "\n" }.count + 1)
         XCTAssertNotEqual("\n", string.last)
 
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: charsPerFrag)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: charsPerFrag)
 
         // First line: a single fragment that takes up less than the entire width.
         let start0 = string.index(string.startIndex, offsetBy: 0)
@@ -156,7 +156,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
         XCTAssertEqual(2, string.filter { $0 == "\n" }.count + 1)
         XCTAssertEqual("\n", string.last)
 
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: charsPerFrag)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: charsPerFrag)
 
         // First line: two fragments
         let start0 = string.index(string.startIndex, offsetBy: 0)
@@ -182,7 +182,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testLineFragmentRangeFullFragAndNewline() {
         let string = "0123456789\n"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var r = dataSource.lineFragmentRange(containing: string.index(at: 0))
         XCTAssertEqual(0..<11, Range(r, in: string))
@@ -199,7 +199,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testLineFragmentRangeEndIndex() {
         let string = "abc"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // End index returns the last line
         let r = dataSource.lineFragmentRange(containing: string.index(at: 3))
@@ -209,7 +209,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
     // MARK: lineFragmentRange(for:)
     func testLineFragmentRangeForEmpty() {
         let string = ""
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var r = dataSource.lineFragmentRange(for: CGPoint(x: 0, y: -0.001))
         XCTAssertNil(r)
@@ -226,7 +226,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testLineFragmentRangeForNewline() {
         let string = "\n"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         var r = dataSource.lineFragmentRange(for: CGPoint(x: 0, y: -0.001))
         XCTAssertNil(r)
@@ -253,7 +253,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
         hello
         
         """
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
 
         // before document
         var r = dataSource.lineFragmentRange(for: CGPoint(x: 0, y: -0.001))
@@ -298,7 +298,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetsEmptyLine() {
         let string = ""
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         let offsets = dataSource.carretOffsetsInLineFragment(containing: string.index(at: 0))
 
         XCTAssertEqual(2, offsets.count)
@@ -309,7 +309,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetsOnlyNewline() {
         let string = "\n"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         var offsets = dataSource.carretOffsetsInLineFragment(containing: string.index(at: 0))
 
         XCTAssertEqual(2, offsets.count)
@@ -325,7 +325,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetOneLine() {
         let string = "abc"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         let offsets = dataSource.carretOffsetsInLineFragment(containing: string.startIndex)
 
         XCTAssertEqual(6, offsets.count)
@@ -340,7 +340,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetWithNewline() {
         let string = "abc\n"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         var offsets = dataSource.carretOffsetsInLineFragment(containing: string.index(at: 0))
 
         XCTAssertEqual(8, offsets.count)
@@ -364,7 +364,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetsWithWrap() {
         let string = "0123456789wrap"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         var offsets = dataSource.carretOffsetsInLineFragment(containing: string.index(at: 0))
 
         XCTAssertEqual(20, offsets.count)
@@ -406,7 +406,7 @@ final class SimpleSelectionDataSourceTests: XCTestCase {
 
     func testEnumerateCaretOffsetFullLineFragmentPlusNewline() {
         let string = "0123456789\n"
-        let dataSource = TestSelectionDataSource(string: string, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: string, charsPerLine: 10)
         var offsets = dataSource.carretOffsetsInLineFragment(containing: string.index(at: 0))
 
         XCTAssertEqual(22, offsets.count)

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TextLayoutDataSourceTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TextLayoutDataSourceTests.swift
@@ -1,5 +1,5 @@
 //
-//  SelectionNavigationDataSourceTests.swift
+//  TextLayoutDataSourceTests.swift
 //  
 //
 //  Created by David Albert on 11/8/23.
@@ -8,12 +8,12 @@
 import XCTest
 @testable import StandardKeyBindingResponder
 
-final class SelectionNavigationDataSourceTests: XCTestCase {
+final class TextLayoutDataSourceTests: XCTestCase {
     // MARK: index(forCaretOffset:inLineFragmentWithRange:)
 
     func testIndexForCaretOffsetEmpty() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 0)
 
@@ -24,7 +24,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetOnlyNewline() {
         let s = "\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 1)
 
@@ -36,7 +36,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetSingleCharacter() {
         let s = "a"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 1)
 
@@ -50,7 +50,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetSingleCharacterWithNewline() {
         let s = "a\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 2)
 
@@ -66,7 +66,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetSingleLine() {
         let s = "abc"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 3)
 
@@ -83,7 +83,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetWrap() {
         let s = "0123456789wrap"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = s.index(at: 0)..<s.index(at: 10)
 
@@ -126,7 +126,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testIndexForCaretOffsetFullFragWithNewline() {
         let s = "0123456789\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = s.index(at: 0)..<s.index(at: 11)
 
@@ -169,7 +169,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testCaretOffsetForCharacterAtEmpty() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 0)
 
@@ -178,7 +178,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testCaretOffsetForCharacterAtNewline() {
         let s = "\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = s.index(at: 0)..<s.index(at: 1)
         XCTAssertEqual(0, dataSource.caretOffset(forCharacterAt: s.index(at: 0), inLineFragmentWithRange: r))
@@ -190,7 +190,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testCaretOffsetForCharacterAtSingleCharacter() {
         let s = "a"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = s.index(at: 0)..<s.index(at: 1)
 
@@ -200,7 +200,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testCaretOffsetForCharacterAtNonEmptyWithNewline() {
         let s = "a\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = s.index(at: 0)..<s.index(at: 2)
 
@@ -217,7 +217,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForCharacterEmptyString() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = dataSource.range(for: .character, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<0, Range(r, in: s))
@@ -225,7 +225,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForWordEmptyString() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = dataSource.range(for: .word, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<0, Range(r, in: s))
@@ -233,7 +233,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForLineEmptyString() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<0, Range(r, in: s))
@@ -241,7 +241,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForParagraphEmptyString() {
         let s = ""
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         let r = dataSource.range(for: .paragraph, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<0, Range(r, in: s))
@@ -249,7 +249,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForCharacter() {
         let s = "abc"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .character, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<1, Range(r, in: s))
@@ -266,7 +266,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForWordCharactersAtEdges() {
         let s = "abc   def"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .word, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<3, Range(r, in: s))
@@ -301,7 +301,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForWordWhitespaceAtEdges() {
         let s = "   abc   "
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .word, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<3, Range(r, in: s))
@@ -336,7 +336,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForWordWithNewline() {
         let s = "abc  \n def"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .word, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<3, Range(r, in: s))
@@ -374,7 +374,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForLineSingleFragment() {
         let s = "abc"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<3, Range(r, in: s))
@@ -391,7 +391,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForLineWithNewline() {
         let s = "abc\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<4, Range(r, in: s))
@@ -411,7 +411,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForFullLine() {
         let s = "0123456789"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<10, Range(r, in: s))
@@ -428,7 +428,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForFullLineWithTrailingNewline() {
         let s = "0123456789\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<11, Range(r, in: s))
@@ -448,7 +448,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForWrappedLine() {
         let s = "0123456789wrap"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .line, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<10, Range(r, in: s))
@@ -471,7 +471,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForParagraph() {
         let s = "0123456789wrap\n0123456789wrap"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .paragraph, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<15, Range(r, in: s))
@@ -491,7 +491,7 @@ final class SelectionNavigationDataSourceTests: XCTestCase {
 
     func testRangeForParagraphWithTrailingNewline() {
         let s = "foo\nbar\n"
-        let dataSource = TestSelectionDataSource(string: s, charsPerLine: 10)
+        let dataSource = TestTextLayoutDataSource(string: s, charsPerLine: 10)
 
         var r = dataSource.range(for: .paragraph, enclosing: s.index(at: 0))
         XCTAssertEqual(0..<4, Range(r, in: s))

--- a/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TransposerTests.swift
+++ b/StandardKeyBindingResponder/Tests/StandardKeyBindingResponderTests/TransposerTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import StandardKeyBindingResponder
 
-fileprivate extension DocumentContentDataSource {
+fileprivate extension TextContentDataSource {
     func index(at offset: Int) -> Index {
         index(startIndex, offsetBy: offset)
     }
@@ -16,7 +16,7 @@ fileprivate extension DocumentContentDataSource {
 
 final class TransposerTests: XCTestCase {
     func testIndicesForTranspose() {
-        let tests: [(SimpleContentDataSource, Range<Int>, (Int, Int)?)] = [
+        let tests: [(TestTextContentDataSource, Range<Int>, (Int, Int)?)] = [
             ("", 0..<0, nil),          // empty document
             ("abcde", 0..<0, (0, 1)),  // caret at beginning
             ("abcde", 1..<1, (0, 1)),  // caret in between
@@ -42,7 +42,7 @@ final class TransposerTests: XCTestCase {
     }
 
     func testRangesForTransposeWords() {
-        func t(_ dataSource: SimpleContentDataSource, _ range: Range<Int>, _ expected: (Range<Int>, Range<Int>)?, file: StaticString = #file, line: UInt = #line) {
+        func t(_ dataSource: TestTextContentDataSource, _ range: Range<Int>, _ expected: (Range<Int>, Range<Int>)?, file: StaticString = #file, line: UInt = #line) {
             let r = dataSource.index(at: range.lowerBound)..<dataSource.index(at: range.upperBound)
             let result = Transposer.rangesForTransposeWords(inSelectedRange: r, dataSource: dataSource)
 

--- a/Watt.xcodeproj/project.pbxproj
+++ b/Watt.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		6315D3002A9B769100B8A077 /* AttributedRope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6315D2FF2A9B769100B8A077 /* AttributedRope.swift */; };
 		6315D3022A9BD00F00B8A077 /* AttributedRopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6315D3012A9BD00F00B8A077 /* AttributedRopeTests.swift */; };
 		631FD2652A696D27005FA854 /* Heights.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631FD2642A696D27005FA854 /* Heights.swift */; };
-		63207CB12B374FC60052F451 /* Stdlib+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63207CB02B374FC60052F451 /* Stdlib+Extensions.swift */; };
 		63286AE22A13DF5D00839B25 /* ClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63286AE12A13DF5D00839B25 /* ClipView.swift */; };
 		63359A3E2AA9115100082762 /* TreeSitterC in Frameworks */ = {isa = PBXBuildFile; productRef = 63359A3D2AA9115100082762 /* TreeSitterC */; };
 		6346D1952A06EC2900CFB7EE /* TextContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6346D1942A06EC2900CFB7EE /* TextContainer.swift */; };
@@ -44,6 +43,7 @@
 		637BC1442A156B820089A34D /* CGPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BC1432A156B820089A34D /* CGPoint+Extensions.swift */; };
 		637BC1462A156B9B0089A34D /* CGSize+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637BC1452A156B9B0089A34D /* CGSize+Extensions.swift */; };
 		63820B8D2A7164A500CC7458 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63820B8C2A7164A500CC7458 /* Collection+Extensions.swift */; };
+		6396DD262B433781000F85D1 /* Comparable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6396DD252B433775000F85D1 /* Comparable+Extensions.swift */; };
 		63A618622A0C3AE200E70B0E /* Moby Dick.txt in Resources */ = {isa = PBXBuildFile; fileRef = 63A618612A0C3AE200E70B0E /* Moby Dick.txt */; };
 		63A618722A0EAF2000E70B0E /* Weak.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618712A0EAF2000E70B0E /* Weak.swift */; };
 		63A618742A0EC37700E70B0E /* LineNumberView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63A618732A0EC37700E70B0E /* LineNumberView.swift */; };
@@ -94,7 +94,6 @@
 		6315D2FF2A9B769100B8A077 /* AttributedRope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedRope.swift; sourceTree = "<group>"; };
 		6315D3012A9BD00F00B8A077 /* AttributedRopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AttributedRopeTests.swift; path = WattTests/AttributedRopeTests.swift; sourceTree = SOURCE_ROOT; };
 		631FD2642A696D27005FA854 /* Heights.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Heights.swift; sourceTree = "<group>"; };
-		63207CB02B374FC60052F451 /* Stdlib+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Stdlib+Extensions.swift"; sourceTree = "<group>"; };
 		63286AE12A13DF5D00839B25 /* ClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipView.swift; sourceTree = "<group>"; };
 		6346D1942A06EC2900CFB7EE /* TextContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextContainer.swift; sourceTree = "<group>"; };
 		634A70A42B1F7A1700BDD0D3 /* AssertPreconditionViolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssertPreconditionViolation.swift; sourceTree = "<group>"; };
@@ -133,6 +132,7 @@
 		637BC1452A156B9B0089A34D /* CGSize+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGSize+Extensions.swift"; sourceTree = "<group>"; };
 		63820B8C2A7164A500CC7458 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
 		6384CA642B1959610087FC14 /* lldb_utils.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = lldb_utils.py; sourceTree = "<group>"; };
+		6396DD252B433775000F85D1 /* Comparable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Extensions.swift"; sourceTree = "<group>"; };
 		6396DEFD2AA9074D00B1D03B /* TreeSitterLanguages */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TreeSitterLanguages; sourceTree = "<group>"; };
 		63A618612A0C3AE200E70B0E /* Moby Dick.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Moby Dick.txt"; sourceTree = "<group>"; };
 		63A618712A0EAF2000E70B0E /* Weak.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weak.swift; sourceTree = "<group>"; };
@@ -247,10 +247,10 @@
 				63F25BD82A683CC500DEACCF /* Buffer.swift */,
 				637BC1432A156B820089A34D /* CGPoint+Extensions.swift */,
 				637BC1412A156B620089A34D /* CGRect+Extensions.swift */,
-				63207CB02B374FC60052F451 /* Stdlib+Extensions.swift */,
 				637BC1452A156B9B0089A34D /* CGSize+Extensions.swift */,
 				63286AE12A13DF5D00839B25 /* ClipView.swift */,
 				63820B8C2A7164A500CC7458 /* Collection+Extensions.swift */,
+				6396DD252B433775000F85D1 /* Comparable+Extensions.swift */,
 				6372888D29FD8E19005B95E5 /* Document.swift */,
 				631FD2642A696D27005FA854 /* Heights.swift */,
 				635B36AE2AAE5424002FAE70 /* Highlighter.swift */,
@@ -477,6 +477,7 @@
 				637BC1422A156B620089A34D /* CGRect+Extensions.swift in Sources */,
 				637BC1442A156B820089A34D /* CGPoint+Extensions.swift in Sources */,
 				6346D1952A06EC2900CFB7EE /* TextContainer.swift in Sources */,
+				6396DD262B433781000F85D1 /* Comparable+Extensions.swift in Sources */,
 				63B8B1762A9F890100F32C2C /* Utilities.swift in Sources */,
 				63F25BE12A689D2400DEACCF /* Line.swift in Sources */,
 				637867872A1FB2C50039960E /* NSRange+Extensions.swift in Sources */,
@@ -508,7 +509,6 @@
 				635B36AB2AAE1D94002FAE70 /* String+Extensions.swift in Sources */,
 				637867852A1EC6BB0039960E /* TextView+KeyBinding.swift in Sources */,
 				635B36AF2AAE5424002FAE70 /* Highlighter.swift in Sources */,
-				63207CB12B374FC60052F451 /* Stdlib+Extensions.swift in Sources */,
 				635B36B12AAFCD95002FAE70 /* Theme.swift in Sources */,
 				63B61A1629FDA2B800787BB9 /* TextView.swift in Sources */,
 				63820B8D2A7164A500CC7458 /* Collection+Extensions.swift in Sources */,

--- a/Watt/BTree.swift
+++ b/Watt/BTree.swift
@@ -524,33 +524,27 @@ extension BTreeNode {
         @discardableResult
         mutating func prev<M>(using metric: M) -> Int? where M: BTreeMetric<Summary> {
             assert(rootStorage != nil)
-
-            if leaf == nil {
-                return nil
-            }
-
-            if position == 0 {
+            if leaf == nil || position == 0 {
                 invalidate()
                 return nil
             }
 
             // try to find a boundary within this leaf
-            if let offset = prev(withinLeafUsing: metric) {
-                return offset
+            let origPos = position
+            if offsetInLeaf > 0 {
+                if let newOffsetInLeaf = metric.prev(offsetInLeaf, in: leaf!) {
+                    position = offsetOfLeaf + newOffsetInLeaf
+                    return position
+                }
             }
-
-            // If we didn't find a boundary, go to the previous leaf and
-            // try again.
+    
+            // We didn't find a boundary, go to the previous leaf and try again.
             if prevLeaf() == nil {
-                // We were on the first leaf, so we're done.
-                // prevLeaf invalidates if necessary
+                // We were in the first leaf. We're done.
                 return nil
             }
-
-            // one more shot
-            position = offsetOfLeaf + leaf!.count
-            if let offset = prev(withinLeafUsing: metric) {
-                return offset
+            if let position = last(withinLeafUsing: metric, originalPosition: origPos) {
+                return position
             }
 
             // We've searched at least one full leaf backwards and
@@ -558,48 +552,59 @@ extension BTreeNode {
             //
             // TODO: it's possible this only works with trailing boundaries, but
             // I'm not sure.
-            let measure = measure(upToLeafContaining: offsetOfLeaf, using: metric)
+            let measure = measure(upToLeafContaining: position, using: metric)
             descend(toLeafContaining: measure, asMeasuredBy: metric)
+            if let pos = last(withinLeafUsing: metric, originalPosition: origPos) {
+                return pos
+            }
+            invalidate()
+            return nil
+        }
 
-            // We're always valid after the above two lines
-            position = offsetOfLeaf + leaf!.count
-            if let offset = prev(withinLeafUsing: metric) {
-                return offset
+        // Searches for the last boundary in the current leaf.
+        //
+        // If the last boundary is at the end of the leaf, it's only valid if
+        // it's less than originalPosition.
+        mutating func last<M>(withinLeafUsing metric: M, originalPosition: Int) -> Int? where M: BTreeMetric<Summary> {
+            assert(rootStorage != nil && leaf != nil)
+            if offsetOfLeaf + leaf!.count < originalPosition && metric.isBoundary(leaf!.count, in: leaf!) {
+                nextLeaf()
+                return position
+            }
+            if let newOffsetInLeaf = metric.prev(leaf!.count, in: leaf!) {
+                position = offsetOfLeaf + newOffsetInLeaf
+                return position
+            }
+            if offsetOfLeaf == 0 && (metric.type == .leading || metric.type == .atomic) {
+                // Didn't find a boundary, but leading and atomic metrics have a boundary at startIndex.
+                position = 0
+                return position
             }
 
-            // we didn't find anything
-            invalidate()
             return nil
         }
 
         @discardableResult
         mutating func next<M>(using metric: M) -> Int? where M: BTreeMetric<Summary> {
             assert(rootStorage != nil)
-
-            if leaf == nil {
-                return nil
-            }
-
-            if position == rootStorage!.count {
+            if leaf == nil || position == rootStorage!.count {
                 invalidate()
                 return nil
             }
 
-            if let offset = next(withinLeafUsing: metric) {
-                return offset
+            if let pos = next(withinLeafUsing: metric) {
+                return pos
             }
 
-            // There was no boundary in the leaf we started on. Move to the next one.
+            // We didn't find a boundary, go to the next leaf and try again.
             if nextLeaf() == nil {
-                // the leaf we started on was the last leaf, and we didn't
-                // find a boundary, so now we're at the end. nextLeaf() will
-                // call invalidate() in this case.
+                // We were in the last leaf. We're done.
                 return nil
             }
 
             // one more shot
-            if let offset = next(withinLeafUsing: metric) {
-                return offset
+            if let pos = next(withinLeafUsing: metric) {
+                return pos
             }
 
             // We've searched at least one full leaf forwards and
@@ -607,39 +612,15 @@ extension BTreeNode {
             //
             // TODO: it's possible this only works with trailing boundaries, but
             // I'm not sure.
-            let measure = measure(upToLeafContaining: offsetOfLeaf, using: metric)
+            let measure = measure(upToLeafContaining: position, using: metric)
             descend(toLeafContaining: measure+1, asMeasuredBy: metric)
 
-            if let offset = next(withinLeafUsing: metric) {
-                return offset
+            if let pos = next(withinLeafUsing: metric) {
+                return pos
             }
 
             // we didn't find anything
             invalidate()
-            return nil
-        }
-
-        mutating func prev<M>(withinLeafUsing metric: M) -> Int? where M: BTreeMetric<Summary> {
-            assert(rootStorage != nil && leaf != nil)
-
-            if offsetInLeaf == 0 {
-                return nil
-            }
-
-            let newOffsetInLeaf = metric.prev(offsetInLeaf, in: leaf!)
-            if let newOffsetInLeaf {
-                position = offsetOfLeaf + newOffsetInLeaf
-                return position
-            }
-
-            if offsetOfLeaf == 0 && (metric.type == .trailing || metric.type == .atomic) {
-                // Didn't find a boundary, but trailing and atomic metrics have
-                // a boundary at startIndex.
-                position = 0
-                return position
-            }
-
-            // We didn't find a boundary.
             return nil
         }
 
@@ -650,8 +631,7 @@ extension BTreeNode {
 
             let newOffsetInLeaf = metric.next(offsetInLeaf, in: leaf!)
             if newOffsetInLeaf == nil && isLastLeaf && (metric.type == .leading || metric.type == .atomic) {
-                // Didn't find a boundary, but leading and atomic metrics have a
-                // boundary at endIndex.
+                // Didn't find a boundary, but leading and atomic metrics have a boundary at endIndex.
                 position = offsetOfLeaf + leaf!.count
                 return position
             }

--- a/Watt/BTree.swift
+++ b/Watt/BTree.swift
@@ -1759,6 +1759,15 @@ struct BTreeDelta<Tree> where Tree: BTree {
     var elements: [DeltaElement]
     var baseCount: Int // the count of the associated BTree before applying the delta.
 
+    // An empty delta contains no changes. It doesn't mean elements will be empty.
+    //
+    // Specifically, an empty delta contains one or more adjacent copies that
+    // span 0..<baseCount.
+    var isEmpty: Bool {
+        let (replacementRange, newCount) = summary()
+        return replacementRange.isEmpty && newCount == 0
+    }
+
     // Returns a range covering the entire changed portion of the
     // original tree and the length of the newly inserted tree.
     func summary() -> (replacementRange: Range<Int>, newCount: Int) {

--- a/Watt/Buffer.swift
+++ b/Watt/Buffer.swift
@@ -292,7 +292,7 @@ extension Buffer: HighlighterDelegate {
     }
 }
 
-extension Buffer: DocumentContentDataSource {
+extension Buffer: TextContentDataSource {
     var characterCount: Int {
         count
     }

--- a/Watt/Buffer.swift
+++ b/Watt/Buffer.swift
@@ -196,12 +196,20 @@ class Buffer {
     //
     // This will also be important for Undo/Redo.
     func replaceSubrange(_ subrange: Range<Index>, with attrRope: AttributedRope) {
+        if subrange.isEmpty && attrRope.isEmpty {
+            return
+        }
+
         var b = AttributedRope.DeltaBuilder(contents)
         b.replaceSubrange(subrange, with: attrRope)
         applying(delta: b.build())
     }
 
     func replaceSubrange(_ subrange: Range<Index>, with s: String) {
+        if subrange.isEmpty && s.isEmpty {
+            return
+        }
+
         var b = AttributedRope.DeltaBuilder(contents)
         b.replaceSubrange(subrange, with: s)
         applying(delta: b.build())

--- a/Watt/CGPoint+Extensions.swift
+++ b/Watt/CGPoint+Extensions.swift
@@ -14,3 +14,8 @@ extension CGPoint: Hashable {
     }
 }
 
+extension CGPoint {
+    func clamped(to rect: CGRect) -> CGPoint {
+        CGPoint(x: x.clamped(to: rect.minX...rect.maxX), y: y.clamped(to: rect.minY...rect.maxY))
+    }
+}

--- a/Watt/Comparable+Extensions.swift
+++ b/Watt/Comparable+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  Stdlib+Extensions.swift
+//  Comparable+Extensions.swift
 //  Watt
 //
 //  Created by David Albert on 12/23/23.

--- a/Watt/LayoutManager.swift
+++ b/Watt/LayoutManager.swift
@@ -786,7 +786,7 @@ extension LayoutManager {
 }
 
 
-extension LayoutManager: SelectionNavigationDataSource {
+extension LayoutManager: TextLayoutDataSource {
     var characterCount: Int {
         buffer.characterCount
     }

--- a/Watt/Rope.swift
+++ b/Watt/Rope.swift
@@ -904,8 +904,11 @@ extension Rope: BidirectionalCollection {
 
 extension Rope: RangeReplaceableCollection {
     mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C: Collection, C.Element == Element {
-        let rangeStart = index(roundingDown: subrange.lowerBound)
-        let rangeEnd = index(roundingDown: subrange.upperBound)
+        subrange.lowerBound.validate(for: self)
+        subrange.upperBound.validate(for: self)
+        
+        let rangeStart = unicodeScalars.index(roundingDown: subrange.lowerBound)
+        let rangeEnd = unicodeScalars.index(roundingDown: subrange.upperBound)
 
         // We have to ensure that root isn't mutated directly because that would
         // invalidate indices and counts when we push the suffix (rangeEnd..<endIndex)
@@ -1034,7 +1037,8 @@ extension Rope {
                 return
             }
 
-            let prev = chunk.characters.index(before: i)
+            let j = chunk.characters._index(roundingDown: i)
+            let prev = j == i ? chunk.characters.index(before: i) : j
 
             self.init(consuming: chunk.string[prev..<i])
         }

--- a/Watt/Rope.swift
+++ b/Watt/Rope.swift
@@ -906,7 +906,7 @@ extension Rope: RangeReplaceableCollection {
     mutating func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C: Collection, C.Element == Element {
         subrange.lowerBound.validate(for: self)
         subrange.upperBound.validate(for: self)
-        
+
         let rangeStart = unicodeScalars.index(roundingDown: subrange.lowerBound)
         let rangeEnd = unicodeScalars.index(roundingDown: subrange.upperBound)
 
@@ -1577,7 +1577,7 @@ extension Rope: Equatable {
 // TODO: normalized comparisons
 extension Subrope: Equatable {
     static func == (lhs: Subrope, rhs: Subrope) -> Bool {
-        if lhs.base.root == rhs.base.root && Range(uncheckedRange: lhs.bounds) == Range(uncheckedRange: rhs.bounds) {
+        if lhs.base.root == rhs.base.root && Range(unvalidatedRange: lhs.bounds) == Range(unvalidatedRange: rhs.bounds) {
             return true
         }
         return Rope(lhs) == Rope(rhs)
@@ -1675,7 +1675,7 @@ extension Range where Bound == Rope.Index {
 
 extension Range where Bound == Int {
     // Don't use for user provided ranges.
-    init(uncheckedRange range: Range<Rope.Index>) {
+    init(unvalidatedRange range: Range<Rope.Index>) {
         self.init(uncheckedBounds: (range.lowerBound.position, range.upperBound.position))
     }
 

--- a/Watt/Rope.swift
+++ b/Watt/Rope.swift
@@ -467,10 +467,13 @@ extension Rope {
         }
 
         func isBoundary(_ offset: Int, in chunk: Chunk) -> Bool {
-            assert(offset < chunk.count)
+            assert(offset <= chunk.count)
 
             if offset < chunk.prefixCount {
                 return false
+            }
+            if offset == chunk.count {
+                return !chunk.lastCharSplits
             }
 
             let i = chunk.string.utf8Index(at: offset)

--- a/Watt/TextView+Input.swift
+++ b/Watt/TextView+Input.swift
@@ -196,13 +196,21 @@ extension TextView {
     }
 
     func replaceSubrange(_ subrange: Range<Buffer.Index>, with s: AttributedRope) {
-        buffer.replaceSubrange(subrange, with: s)
-        updateStateAfterReplacingSubrange(subrange, withStringOfCount: s.count)
+        let start = buffer.text.unicodeScalars.index(roundingDown: subrange.lowerBound)
+        let end = buffer.text.unicodeScalars.index(roundingDown: subrange.upperBound)
+        let r = start..<end
+
+        buffer.replaceSubrange(r, with: s)
+        updateStateAfterReplacingSubrange(r, withStringOfCount: s.count)
     }
 
     func replaceSubrange(_ subrange: Range<Buffer.Index>, with s: String) {
-        buffer.replaceSubrange(subrange, with: s)
-        updateStateAfterReplacingSubrange(subrange, withStringOfCount: s.count)
+        let start = buffer.text.unicodeScalars.index(roundingDown: subrange.lowerBound)
+        let end = buffer.text.unicodeScalars.index(roundingDown: subrange.upperBound)
+        let r = start..<end
+
+        buffer.replaceSubrange(r, with: s)
+        updateStateAfterReplacingSubrange(r, withStringOfCount: s.count)
     }
 
     func updateStateAfterReplacingSubrange(_ subrange: Range<Buffer.Index>, withStringOfCount count: Int) {

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -524,26 +524,8 @@ extension TextView {
     }
 
     override func deleteBackwardByDecomposingPreviousCharacter(_ sender: Any?) {
-        if selection.isRange {
-            replaceSubrange(selection.range, with: "")
-            unmarkText()
-            return
-        }
-
-        if selection.lowerBound == buffer.startIndex {
-            return
-        }
-
-        let i = buffer.index(before: selection.lowerBound)
-        var s = String(buffer[i]).decomposedStringWithCanonicalMapping
-        s.unicodeScalars.removeLast()
-
-        // If we left a trailing Zero Width Joiner, remove that too.
-        if s.unicodeScalars.last == "\u{200d}" {
-            s.unicodeScalars.removeLast()
-        }
-
-        replaceSubrange(i..<selection.lowerBound, with: s)
+        let (range, s) = SelectionNavigator.replacementDecomposingPreviousCharacter(for: selection, dataSource: layoutManager)
+        replaceSubrange(range, with: s)
         unmarkText()
     }
 

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -118,12 +118,11 @@ extension TextView {
         if rect.height < viewport.height {
             scrollToCenter(rect)
         } else if viewport.minY < rect.minY {
-            let target = convertFromTextContainer(r1.origin)
-            scroll(target)
+            let target = r1.origin
+            scroll(convertFromTextContainer(target))
         } else if rect.maxY < viewport.maxY {
-            let bottomLeft = convertFromTextContainer(CGPoint(x: r2.minX, y: r2.maxY))
-            let target = CGPoint(x: bottomLeft.x, y: bottomLeft.y - viewport.height)
-            scroll(target)
+            let target = CGPoint(x: r2.minX, y: r2.maxY - viewport.height)
+            scroll(convertFromTextContainer(target))
         }
     }
 

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -98,23 +98,33 @@ extension TextView {
     }
 
     override func centerSelectionInVisibleArea(_ sender: Any?) {
-        let rect: CGRect
         if selection.isCaret {
-            let r = layoutManager.caretRect(for: selection.head, affinity: selection.affinity)
-            guard let r else {
+            guard let rect = layoutManager.caretRect(for: selection.head, affinity: selection.affinity) else {
                 return
             }
-            rect = r
-        } else {
-            let r1 = layoutManager.caretRect(for: layoutManager.selection.lowerBound, affinity: .downstream)
-            let r2 = layoutManager.caretRect(for: layoutManager.selection.upperBound, affinity: .upstream)
-            guard let r1, let r2 else {
-                return
-            }
-            rect = r1.union(r2)
+            scrollToCenter(rect)
+            return
         }
 
-        scrollToCenter(rect)
+        let r1 = layoutManager.caretRect(for: layoutManager.selection.lowerBound, affinity: .downstream)
+        let r2 = layoutManager.caretRect(for: layoutManager.selection.upperBound, affinity: .upstream)
+        guard let r1, let r2 else {
+            return
+        }
+        let rect = r1.union(r2)
+
+        let viewport = textContainerVisibleRect
+
+        if rect.height < viewport.height {
+            scrollToCenter(rect)
+        } else if viewport.minY < rect.minY {
+            let target = convertFromTextContainer(r1.origin)
+            scroll(target)
+        } else if rect.maxY < viewport.maxY {
+            let bottomLeft = convertFromTextContainer(CGPoint(x: r2.minX, y: r2.maxY))
+            let target = CGPoint(x: bottomLeft.x, y: bottomLeft.y - viewport.height)
+            scroll(target)
+        }
     }
 
 

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -512,22 +512,14 @@ extension TextView {
     // MARK: - Deletions
 
     override func deleteForward(_ sender: Any?) {
-        if selection.isRange {
-            replaceSubrange(selection.range, with: "")
-        } else if selection.lowerBound < buffer.endIndex {
-            let end = buffer.index(after: selection.lowerBound)
-            replaceSubrange(selection.lowerBound..<end, with: "")
-        }
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .right, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
         unmarkText()
     }
 
     override func deleteBackward(_ sender: Any?) {
-        if selection.isRange {
-            replaceSubrange(selection.range, with: "")
-        } else if selection.lowerBound > buffer.startIndex {
-            let start = buffer.index(before: selection.lowerBound)
-            replaceSubrange(start..<selection.lowerBound, with: "")
-        }
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .left, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
         unmarkText()
     }
 
@@ -536,59 +528,39 @@ extension TextView {
     }
 
     override func deleteWordForward(_ sender: Any?) {
-        if selection.isRange {
-            replaceSubrange(selection.range, with: "")
-        } else if selection.lowerBound < buffer.endIndex {
-            let caret = selection.lowerBound
-            var end = caret
-
-            while end < buffer.endIndex && !isWordChar(buffer[end]) {
-                end = buffer.index(after: end)
-            }
-            while end < buffer.endIndex && isWordChar(buffer[end]) {
-                end = buffer.index(after: end)
-            }
-
-            replaceSubrange(caret..<end, with: "")
-        }
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .wordRight, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
         unmarkText()
     }
 
     override func deleteWordBackward(_ sender: Any?) {
-        if selection.isRange {
-            replaceSubrange(selection.range, with: "")
-        } else if selection.lowerBound > buffer.startIndex {
-            let caret = selection.lowerBound
-            var start = buffer.index(before: caret)
-
-            // TODO: isWordChar should be defined elsewhere I think. Maybe StandardKeyBindingResponder?
-            while start > buffer.startIndex && !isWordChar(buffer[buffer.index(before: start)]) {
-                start = buffer.index(before: start)
-            }
-
-            while start > buffer.startIndex && isWordChar(buffer[buffer.index(before: start)]) {
-                start = buffer.index(before: start)
-            }
-
-            replaceSubrange(start..<caret, with: "")
-        }
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .wordLeft, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
         unmarkText()
     }
 
     override func deleteToBeginningOfLine(_ sender: Any?) {
-
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .beginningOfLine, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
+        unmarkText()
     }
 
     override func deleteToEndOfLine(_ sender: Any?) {
-
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .endOfLine, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
+        unmarkText()
     }
 
     override func deleteToBeginningOfParagraph(_ sender: Any?) {
-
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .beginningOfParagraph, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
+        unmarkText()
     }
 
     override func deleteToEndOfParagraph(_ sender: Any?) {
-
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .endOfParagraph, dataSource: layoutManager)
+        replaceSubrange(range, with: "")
+        unmarkText()
     }
 
 
@@ -664,8 +636,4 @@ extension TextView {
     override func quickLookPreviewItems(_ sender: Any?) {
 
     }
-}
-
-fileprivate func isWordChar(_ c: Character) -> Bool {
-    !c.isWhitespace && !c.isPunctuation
 }

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -524,7 +524,7 @@ extension TextView {
     }
 
     override func deleteBackwardByDecomposingPreviousCharacter(_ sender: Any?) {
-        let (range, s) = SelectionNavigator.replacementDecomposingPreviousCharacter(for: selection, dataSource: layoutManager)
+        let (range, s) = SelectionNavigator.replacementForDeleteBackwardsByDecomposing(selection, dataSource: layoutManager)
         replaceSubrange(range, with: s)
         unmarkText()
     }

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -524,7 +524,27 @@ extension TextView {
     }
 
     override func deleteBackwardByDecomposingPreviousCharacter(_ sender: Any?) {
+        if selection.isRange {
+            replaceSubrange(selection.range, with: "")
+            unmarkText()
+            return
+        }
 
+        if selection.lowerBound == buffer.startIndex {
+            return
+        }
+
+        let i = buffer.index(before: selection.lowerBound)
+        var s = String(buffer[i]).decomposedStringWithCanonicalMapping
+        s.unicodeScalars.removeLast()
+
+        // If we left a trailing Zero Width Joiner, remove that too.
+        if s.unicodeScalars.last == "\u{200d}" {
+            s.unicodeScalars.removeLast()
+        }
+
+        replaceSubrange(i..<selection.lowerBound, with: s)
+        unmarkText()
     }
 
     override func deleteWordForward(_ sender: Any?) {

--- a/Watt/TextView+KeyBinding.swift
+++ b/Watt/TextView+KeyBinding.swift
@@ -539,8 +539,14 @@ extension TextView {
         unmarkText()
     }
 
+    // Follow Xcode's lead and make deleteToBeginningOfLine: behave like deleteToBeginningOfParagraph:.
+    // I imagine this is because StandardKeyBinding.dict only includes deleteToBeginningOfLine: and
+    // deleteToEndOfPargraph: and in a text editor it's more useful for Command-Delete to delete to
+    // the beginning of the line, not the line fragment.
+    //
+    // Perhaps this would be a good place for some sort of preference in the future.
     override func deleteToBeginningOfLine(_ sender: Any?) {
-        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .beginningOfLine, dataSource: layoutManager)
+        let range = SelectionNavigator.rangeToDelete(for: selection, movement: .beginningOfParagraph, dataSource: layoutManager)
         replaceSubrange(range, with: "")
         unmarkText()
     }

--- a/Watt/TextView+Layout.swift
+++ b/Watt/TextView+Layout.swift
@@ -191,7 +191,7 @@ extension TextView {
     }
 
     func scrollIndexToCenter(_ index: Buffer.Index) {
-        guard var rect = layoutManager.caretRect(for: index, affinity: index == buffer.endIndex ? .upstream : .downstream) else {
+        guard let rect = layoutManager.caretRect(for: index, affinity: index == buffer.endIndex ? .upstream : .downstream) else {
             return
         }
 

--- a/Watt/TextView+Mouse.swift
+++ b/Watt/TextView+Mouse.swift
@@ -49,8 +49,8 @@ extension TextView {
             case .periodic:
                 autoscroll(with: mouseEvent)
                 extendSelection(with: mouseEvent)
-                // Don't dispatch periodic events to NSApp. Doesn't really matter in practice,
-                // but NSApp doesn't expect periodic events, so let's not rock the boat.
+                // Don't dispatch periodic events to NSApp. Doesn't really matter in practice, but
+                // NSApp doesn't normally receive periodic events, so let's not rock the boat.
                 continue
             case .leftMouseUp:
                 done = true

--- a/Watt/TextView+Mouse.swift
+++ b/Watt/TextView+Mouse.swift
@@ -56,7 +56,6 @@ extension TextView {
                 mouseEvent = nextEvent
             default:
                 print("Unexpected event type \(nextEvent.type)")
-                done = true
             }
 
             NSApp.sendEvent(nextEvent)

--- a/Watt/TextView+Mouse.swift
+++ b/Watt/TextView+Mouse.swift
@@ -49,7 +49,9 @@ extension TextView {
             case .periodic:
                 autoscroll(with: mouseEvent)
                 extendSelection(with: mouseEvent)
-                continue // don't sendEvent
+                // Don't dispatch periodic events to NSApp. Doesn't really matter in practice,
+                // but NSApp doesn't expect periodic events, so let's not rock the boat.
+                continue
             case .leftMouseUp:
                 done = true
             case .leftMouseDragged:

--- a/Watt/TextView.swift
+++ b/Watt/TextView.swift
@@ -108,7 +108,7 @@ class TextView: NSView, ClipViewDelegate {
             // when they're needed in layoutManager(_:attributedRopeFor:).
             buffer.mergeAttributes(defaultAttributes)
 
-            lineNumberView.buffer = buffer
+            lineNumberView.lineCount = buffer.lines.count
         }
     }
 
@@ -176,9 +176,8 @@ class TextView: NSView, ClipViewDelegate {
         layoutManager.buffer = buffer
 
         layoutManager.delegate = self
-        layoutManager.lineNumberDelegate = lineNumberView
-        
-        lineNumberView.buffer = buffer
+
+        lineNumberView.lineCount = buffer.lines.count
         lineNumberView.font = font
         lineNumberView.textColor = theme.lineNumberColor
         lineNumberView.backgroundColor = backgroundColor

--- a/WattTests/BufferTests.swift
+++ b/WattTests/BufferTests.swift
@@ -146,4 +146,40 @@ final class BufferTests: XCTestCase {
 
         XCTAssertNil(iter.next())
     }
+
+    func testReplaceSubrangeOnUnicodeScalarBoundary() {
+        let b = Buffer("a\u{0301}b", language: .plainText) // áb
+        let start = b.text.unicodeScalars.index(b.text.startIndex, offsetBy: 1)
+        let end = b.text.unicodeScalars.index(b.text.startIndex, offsetBy: 2)
+
+        b.replaceSubrange(start..<end, with: "")
+        XCTAssertEqual(b.text, "ab")
+    }
+
+    func testReplaceSubrangeWithAttributedRopeOnUnicodeScalarBoundary() {
+        let b = Buffer("a\u{0301}b", language: .plainText) // áb
+        let start = b.text.unicodeScalars.index(b.text.startIndex, offsetBy: 1)
+        let end = b.text.unicodeScalars.index(b.text.startIndex, offsetBy: 2)
+
+        b.replaceSubrange(start..<end, with: AttributedRope(""))
+        XCTAssertEqual(b.text, "ab")
+    }
+
+    func testReplaceSubrangeOnUTF8BoundaryShouldRoundDownToUnicodeScalar() {
+        let b = Buffer("a\u{0301}b", language: .plainText) // áb
+        let start = b.text.utf8.index(b.text.utf8.startIndex, offsetBy: 1)
+        let end = b.text.utf8.index(b.text.utf8.startIndex, offsetBy: 2)
+
+        b.replaceSubrange(start..<end, with: "")
+        XCTAssertEqual(b.text, "a\u{0301}b")
+    }
+
+    func testReplaceSubrangeWithAttributedRopeOnUTF8BoundaryShouldRoundDownToUnicodeScalar() {
+        let b = Buffer("a\u{0301}b", language: .plainText) // áb
+        let start = b.text.utf8.index(b.text.utf8.startIndex, offsetBy: 1)
+        let end = b.text.utf8.index(b.text.utf8.startIndex, offsetBy: 2)
+
+        b.replaceSubrange(start..<end, with: AttributedRope(""))
+        XCTAssertEqual(b.text, "a\u{0301}b")
+    }
 }

--- a/WattTests/RopeTests.swift
+++ b/WattTests/RopeTests.swift
@@ -165,6 +165,23 @@ final class RopeTests: XCTestCase {
         XCTAssert(String(repeating: "a", count: 40_000) + String(repeating: "b", count: 710_000) + String(repeating: "a", count: 250_000) == String(r), "not equal")
     }
 
+    func testReplaceSubrangeOnUnicodeScalarBoundary() {
+        var s = "a\u{0301}b"
+        let start1 = s.unicodeScalars.index(s.startIndex, offsetBy: 1)
+        let end1 = s.unicodeScalars.index(s.startIndex, offsetBy: 2)
+
+        s.replaceSubrange(start1..<end1, with: "")
+        XCTAssertEqual("ab", s)
+
+        var r = Rope("a\u{0301}b") // "áb"
+        let start = r.unicodeScalars.index(r.startIndex, offsetBy: 1)
+        let end = r.unicodeScalars.index(r.startIndex, offsetBy: 2)
+        XCTAssertEqual(start.position..<end.position, 1..<3)
+
+        r.replaceSubrange(start..<end, with: "")
+        XCTAssertEqual("ab", String(r))
+    }
+
     func testAppendContentsOfInPlace() {
         var r = Rope("abc")
         r.append(contentsOf: "def")

--- a/WattTests/RopeTests.swift
+++ b/WattTests/RopeTests.swift
@@ -2147,7 +2147,7 @@ final class RopeTests: XCTestCase {
     func testReadLastLineInChunkWhereChunkEndsInNewlineAndIsNotTheLastChunk() {
         // Very contrived. I don't know how to create this situation naturally
         // because of how boundaryForBulkInsert tries to put the "\n" on the right
-        // side of the rope boundary, but it has appeared in the wild.
+        // side of the chunk boundary, but it has appeared in the wild.
         var b = BTreeBuilder<Rope>()
         var breaker = Rope.GraphemeBreaker()
 
@@ -2164,6 +2164,23 @@ final class RopeTests: XCTestCase {
 
         // This shouldn't crash
         XCTAssertEqual(String(repeating: "b", count: 510) + "\n", r.lines[1])
+    }
+
+    func testPreviousNewlineWhenPreviousChunkEndsInNewline() {
+        var r = Rope(String(repeating: "a", count: 999) + "\n")
+        r += String(repeating: "b", count: 1000)
+
+        XCTAssertEqual(1, r.root.height)
+        XCTAssertEqual(2, r.root.children.count)
+        XCTAssertEqual(1000, r.root.children[0].count)
+        XCTAssertEqual(1000, r.root.children[1].count)
+
+        XCTAssertEqual("\n", r.root.children[0].leaf.string.last)
+
+        let i = r.root.index(at: 1500, using: .characters)
+        let j = r.root.index(roundingDown: i, using: .newlines)
+
+        XCTAssertEqual(1000, j.position)
     }
 
     func testMoveToPreviousLineInAFourChunkStretchOfNoNewlines() {


### PR DESCRIPTION
- Use SelectionNavigator for deletion
- Add support for deleteBackwardByDecomposingPreviousCharacter
- Fix centerSelectionInVisibleArea
- Scroll text view while dragging outside the view
- Update line numbers inside TextView, not LayoutManager
- BTree: fix a bug where moving to a previous boundary would skip any boundaries that fell at the end of a leaf.