### PR TITLE
More performance improvements

### DIFF
--- a/Watt.xcodeproj/project.pbxproj
+++ b/Watt.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		63F0468A2A65D3EA001B8DA8 /* BTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F046892A65D3EA001B8DA8 /* BTree.swift */; };
 		63F0468C2A65D3F8001B8DA8 /* Rope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0468B2A65D3F8001B8DA8 /* Rope.swift */; };
 		63F0468F2A65D417001B8DA8 /* RopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F0468E2A65D417001B8DA8 /* RopeTests.swift */; };
+		63F234622BA4E48B007696B4 /* CALayer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F234612BA4E48B007696B4 /* CALayer+Extensions.swift */; };
 		63F25BD92A683CC500DEACCF /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F25BD82A683CC500DEACCF /* Buffer.swift */; };
 		63F25BE12A689D2400DEACCF /* Line.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F25BE02A689D2400DEACCF /* Line.swift */; };
 		63F25BE32A689EA700DEACCF /* LineLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F25BE22A689EA700DEACCF /* LineLayer.swift */; };
@@ -229,6 +230,7 @@
 		63F046892A65D3EA001B8DA8 /* BTree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BTree.swift; sourceTree = "<group>"; };
 		63F0468B2A65D3F8001B8DA8 /* Rope.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Rope.swift; sourceTree = "<group>"; };
 		63F0468E2A65D417001B8DA8 /* RopeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RopeTests.swift; sourceTree = "<group>"; };
+		63F234612BA4E48B007696B4 /* CALayer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+Extensions.swift"; sourceTree = "<group>"; };
 		63F25BD82A683CC500DEACCF /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		63F25BDA2A68409700DEACCF /* LLDBInitFile */ = {isa = PBXFileReference; lastKnownFileType = text; path = LLDBInitFile; sourceTree = "<group>"; };
 		63F25BE02A689D2400DEACCF /* Line.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Line.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 			children = (
 				63DD20E02B73D00A00E55747 /* NSObject+Extensions.h */,
 				63DD20DE2B73CFF200E55747 /* NSObject+Extensions.m */,
+				63F234612BA4E48B007696B4 /* CALayer+Extensions.swift */,
 				637BC1432A156B820089A34D /* CGPoint+Extensions.swift */,
 				637BC1412A156B620089A34D /* CGRect+Extensions.swift */,
 				637BC1452A156B9B0089A34D /* CGSize+Extensions.swift */,
@@ -658,6 +661,7 @@
 				6364DDAC2B6C4A3E00886DE3 /* GenericDocumentViewController.swift in Sources */,
 				63A618762A0FD61B00E70B0E /* TextView+LineNumbers.swift in Sources */,
 				63C2C0502B4F3BB700BFB976 /* Dirent.swift in Sources */,
+				63F234622BA4E48B007696B4 /* CALayer+Extensions.swift in Sources */,
 				63B61A1C29FDA9FB00787BB9 /* LayoutManager.swift in Sources */,
 				63B61A1429FD9E1D00787BB9 /* TextDocumentViewController.swift in Sources */,
 				63D546422AFD927300C72CDE /* TextView+FirstResponder.swift in Sources */,

--- a/Watt/Extensions/CALayer+Extensions.swift
+++ b/Watt/Extensions/CALayer+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  CALayer+Extensions.swift
+//  Watt
+//
+//  Created by David Albert on 3/15/24.
+//
+
+import QuartzCore
+
+extension CALayer {
+    // Faster than setting sublayers = nil and then re-adding.
+    func setSublayers(to new: [CALayer]) {
+        guard let sublayers else {
+            sublayers = new
+            return
+        }
+
+        let diff = new.difference(from: sublayers)
+        for c in diff {
+            switch c {
+            case let .remove(offset: _, element: layer, associatedWith: _):
+                layer.removeFromSuperlayer()
+            case let .insert(offset: i, element: layer, associatedWith: _):
+                insertSublayer(layer, at: UInt32(i))
+            }
+        }
+    }
+}

--- a/Watt/LayoutManager/Line.swift
+++ b/Watt/LayoutManager/Line.swift
@@ -9,9 +9,7 @@ import Foundation
 import CoreGraphics
 import CoreText
 
-struct Line: Identifiable {
-    var id: UUID = UUID()
-
+struct Line {
     // The origin in the text container's coordinate
     // space.
     //

--- a/Watt/LineNumberView/LineNumberLayer.swift
+++ b/Watt/LineNumberView/LineNumberLayer.swift
@@ -8,7 +8,7 @@
 import Cocoa
 
 class LineNumberLayer: CALayer {
-    var lineNumber: Int
+    let lineNumber: Int
     weak var lineNumberView: LineNumberView?
 
     init(lineNumber: Int, lineNumberView: LineNumberView? = nil) {

--- a/Watt/LineNumberView/LineNumberView.swift
+++ b/Watt/LineNumberView/LineNumberView.swift
@@ -27,11 +27,8 @@ class LineNumberView: NSView, CALayerDelegate, NSViewLayerContentScaleDelegate {
     }
 
     var textLayer: CALayer = CALayer()
-//    var layerCache: WeakDictionary<Int, CALayer> = WeakDictionary()
-
     var lineNumberLayers: [LineNumberLayer] = []
     var newLayers: [LineNumberLayer] = []
-//    var firstLine: Int? = nil
 
     override var isFlipped: Bool {
         true

--- a/Watt/LineNumberView/LineNumberView.swift
+++ b/Watt/LineNumberView/LineNumberView.swift
@@ -27,7 +27,11 @@ class LineNumberView: NSView, CALayerDelegate, NSViewLayerContentScaleDelegate {
     }
 
     var textLayer: CALayer = CALayer()
-    var layerCache: WeakDictionary<Int, CALayer> = WeakDictionary()
+//    var layerCache: WeakDictionary<Int, CALayer> = WeakDictionary()
+
+    var lineNumberLayers: [LineNumberLayer] = []
+    var newLayers: [LineNumberLayer] = []
+//    var firstLine: Int? = nil
 
     override var isFlipped: Bool {
         true
@@ -113,28 +117,32 @@ class LineNumberView: NSView, CALayerDelegate, NSViewLayerContentScaleDelegate {
     }
 
     func beginUpdates() {
-        textLayer.sublayers = nil
+        newLayers = []
     }
 
+    // Must be called in ascending lineno order.
     func addLineNumber(_ lineno: Int, withAlignmentFrame alignmentFrame: CGRect) {
-        let l = layerCache[lineno] ?? makeLayer(for: lineno)
+        let l = existingLayer(for: lineno) ?? makeLayer(for: lineno)
         l.position = alignmentFrame.origin
         l.bounds = CGRect(x: 0, y: 0, width: frame.width, height: alignmentFrame.height)
-        layerCache[lineno] = l
-        textLayer.addSublayer(l)
+        newLayers.append(l)
     }
 
     func endUpdates() {
-        // no-op
+        lineNumberLayers = newLayers
+        textLayer.setSublayers(to: lineNumberLayers)
+        newLayers = []
     }
 
-    func layoutManager(_ layoutManager: LayoutManager, lineCountDidChangeFrom old: Int, to new: Int) {
-        if floor(log10(Double(old))) != floor(log10(Double(new))) {
-            invalidateIntrinsicContentSize()
+    func existingLayer(for lineno: Int) -> LineNumberLayer? {
+        let (i, found) = lineNumberLayers.binarySearch { $0.lineNumber.compare(to: lineno) }
+        if found {
+            return lineNumberLayers[i]
         }
+        return nil
     }
 
-    func makeLayer(for lineNumber: Int) -> CALayer {
+    func makeLayer(for lineNumber: Int) -> LineNumberLayer {
         let l = LineNumberLayer(lineNumber: lineNumber, lineNumberView: self)
 
         l.delegate = self

--- a/Watt/Rope/AttributedRope.swift
+++ b/Watt/Rope/AttributedRope.swift
@@ -136,10 +136,11 @@ extension AttributedRope {
         let bounds: Range<Index>
 
         private var spans: SpansSlice<AttributedRope.Attributes> {
+            assert(bounds.lowerBound.position >= 0 && bounds.upperBound.position <= base.text.utf8.count, "Index out of bounds")
             let start = base.spans.index(withBaseOffset: bounds.lowerBound.position)
             let end = base.spans.index(withBaseOffset: bounds.upperBound.position)
 
-            return base.spans[start..<end]
+            return base.spans[Range(uncheckedBounds: (start, end))]
         }
 
         private func spansIndex(for i: Index) -> Spans<AttributedRope.Attributes>.Index {

--- a/Watt/Rope/AttributedRope.swift
+++ b/Watt/Rope/AttributedRope.swift
@@ -586,7 +586,7 @@ extension AttributedSubrope {
     }
 
     mutating func mergeAttributes(_ attributes: AttributedRope.Attributes, mergePolicy: AttributedRope.AttributeMergePolicy = .keepNew) {
-        if bounds.isEmpty {
+        if bounds.lowerBound.position == bounds.upperBound.position {
             return
         }
 

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -162,7 +162,7 @@ protocol BTreeMetric<Summary> {
     // measure(summary:count:edge:) is equivalent to convertFromBaseUnits(_:in:edge:), but it is also
     // used for internal nodes. Edge can be ignored if the metric doesn't fragment because each node
     // will have the same number of leading and trailing edges.
-    func measure(summary: Summary, count: Int, edge: BTreeMetricEdge) -> Unit
+    func measure(summary: borrowing Summary, count: Int, edge: BTreeMetricEdge) -> Unit
 
     // Converts a count of leading or trailing edges in this metric, to trailing edges in the base metric.
     func convertToBaseUnits(_ measuredUnits: Unit, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Int
@@ -173,9 +173,9 @@ protocol BTreeMetric<Summary> {
     // Edge can be ignored if the metric is atomic because in an atomic metric every leading edge is also
     // a trailing edge. N.b. this is different from the situation where edge can be ignored in
     // measure(summary:count:edge:).
-    func isBoundary(_ offset: Int, in leaf: Summary.Leaf, edge: BTreeMetricEdge) -> Bool
-    func prev(_ offset: Int, in leaf: Summary.Leaf, edge: BTreeMetricEdge) -> Int?
-    func next(_ offset: Int, in leaf: Summary.Leaf, edge: BTreeMetricEdge) -> Int?
+    func isBoundary(_ offset: Int, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Bool
+    func prev(_ offset: Int, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Int?
+    func next(_ offset: Int, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Int?
 
     // Can the measured unit in this metric can span multiple leaves.
     var canFragment: Bool { get }

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -165,10 +165,10 @@ protocol BTreeMetric<Summary> {
     func measure(summary: Summary, count: Int, edge: BTreeMetricEdge) -> Unit
 
     // Converts a count of leading or trailing edges in this metric, to trailing edges in the base metric.
-    func convertToBaseUnits(_ measuredUnits: Unit, in leaf: Summary.Leaf, edge: BTreeMetricEdge) -> Int
+    func convertToBaseUnits(_ measuredUnits: Unit, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Int
 
     // Converts a count of trailing edges in the base metric to leading or trailing edges in this metric.
-    func convertToMeasuredUnits(_ baseUnits: Int, in leaf: Summary.Leaf, edge: BTreeMetricEdge) -> Unit
+    func convertToMeasuredUnits(_ baseUnits: Int, in leaf: borrowing Summary.Leaf, edge: BTreeMetricEdge) -> Unit
 
     // Edge can be ignored if the metric is atomic because in an atomic metric every leading edge is also
     // a trailing edge. N.b. this is different from the situation where edge can be ignored in

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -1341,7 +1341,7 @@ extension BTreeNode where Summary: BTreeDefaultMetric {
 
         mutating func next() -> Element? {
             index.assertValid(for: slice.root)
-            if !index.isValid || index >= bounds.upperBound {
+            if !index.isValid || index.position >= bounds.upperBound.position {
                 return nil
             }
             let element = slice[unvalidatedIndex: index]

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -551,6 +551,8 @@ extension BTreeNode {
             self.leafStorage = nil
             self.offsetOfLeaf = -1
 
+            path.reserveCapacity(root.height)
+
             descend()
         }
 

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -619,7 +619,7 @@ extension BTreeNode {
         }
 
         mutating func set(_ position: Int) {
-            precondition((0...rootStorage!.count).contains(position), "Index out of bounds")
+            precondition(position >= 0 && position <= rootStorage!.count, "Index out of bounds")
 
             self.position = position
 

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -1327,10 +1327,11 @@ extension BTreeNode where Summary: BTreeDefaultMetric {
 
         init(slice: Slice, metric: Metric, edge: BTreeMetricEdge) {
             assert(slice.startIndex.baseIndex.position <= slice.endIndex.baseIndex.position)
-            let bounds = Range(uncheckedBounds: (slice.startIndex.baseIndex, slice.endIndex.baseIndex))
+            
+            slice.startIndex.baseIndex.assertValid(for: slice.root)
+            slice.endIndex.baseIndex.assertValid(for: slice.root)
 
-            bounds.lowerBound.assertValid(for: slice.root)
-            bounds.upperBound.assertValid(for: slice.root)
+            let bounds = Range(uncheckedBounds: (slice.startIndex.baseIndex, slice.endIndex.baseIndex))
 
             self.slice = slice
             self.metric = metric

--- a/Watt/Rope/BTree.swift
+++ b/Watt/Rope/BTree.swift
@@ -542,7 +542,7 @@ extension BTreeNode {
         }
 
         init<N>(offsetBy offset: Int, in root: N) where N: BTreeNodeProtocol<Summary> {
-            precondition((0...root.count).contains(offset), "Index out of bounds")
+            precondition(offset >= 0 && offset <= root.count, "Index out of bounds")
 
             self.rootStorage = root.storage
             self.mutationCount = root.mutationCount

--- a/Watt/Rope/Rope.swift
+++ b/Watt/Rope/Rope.swift
@@ -1265,6 +1265,13 @@ extension RopeView {
         bounds.upperBound
     }
 
+    private var btreeBounds: Range<BTreeNode<RopeSummary>.Index> {
+        startIndex.i.assertValid(for: base.root)
+        startIndex.i.assertValid(endIndex.i)
+        assert(startIndex.i.position <= endIndex.i.position)
+        return Range(uncheckedBounds: (startIndex.i, endIndex.i))
+    }
+
     subscript(position: Index) -> Element {
         readElement(at: position.alignment < metric.alignment ? index(roundingDown: position) : position)
     }
@@ -1277,43 +1284,43 @@ extension RopeView {
         if r.lowerBound.alignment >= sliceMetric.alignment {
             start = Index(r.lowerBound.i, alignment: .line)
         } else {
-            start = Index(root.index(roundingDown: r.lowerBound.i, in: startIndex.i..<endIndex.i, using: sliceMetric, edge: edge), alignment: .line)
+            start = Index(root.index(roundingDown: r.lowerBound.i, in: btreeBounds, using: sliceMetric, edge: edge), alignment: .line)
         }
 
         let end: Rope.Index
         if r.upperBound.alignment >= sliceMetric.alignment {
             end = Index(r.upperBound.i, alignment: .line)
         } else {
-            end = Index(root.index(roundingDown: r.upperBound.i, in: startIndex.i..<endIndex.i, using: sliceMetric, edge: edge), alignment: .line)
+            end = Index(root.index(roundingDown: r.upperBound.i, in: btreeBounds, using: sliceMetric, edge: edge), alignment: .line)
         }
 
         return SubSequence(base: base, bounds: start..<end)
     }
 
     func index(before i: consuming Index) -> Index {
-        Index(root.index(before: i.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge, isKnownAligned: i.alignment >= metric.alignment), alignment: metric.alignment)
+        Index(root.index(before: i.i, in: btreeBounds, using: metric, edge: edge, isKnownAligned: i.alignment >= metric.alignment), alignment: metric.alignment)
     }
 
     func index(after i: consuming Index) -> Index {
-        Index(root.index(after: i.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge), alignment: metric.alignment)
+        Index(root.index(after: i.i, in: btreeBounds, using: metric, edge: edge), alignment: metric.alignment)
     }
 
     func index(_ i: consuming Index, offsetBy distance: Int) -> Index {
-        Index(root.index(i.i, offsetBy: distance, in: startIndex.i..<endIndex.i, using: metric, edge: edge), alignment: metric.alignment)
+        Index(root.index(i.i, offsetBy: distance, in: btreeBounds, using: metric, edge: edge), alignment: metric.alignment)
     }
 
     func index(_ i: consuming Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
-        Index(root.index(i.i, offsetBy: distance, limitedBy: limit.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge, isKnownAligned: i.alignment >= metric.alignment), alignment: metric.alignment)
+        Index(root.index(i.i, offsetBy: distance, limitedBy: limit.i, in: btreeBounds, using: metric, edge: edge, isKnownAligned: i.alignment >= metric.alignment), alignment: metric.alignment)
     }
 
     func distance(from start: Index, to end: Index) -> Int {
-        root.distance(from: start.i, to: end.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge)
+        root.distance(from: start.i, to: end.i, in: btreeBounds, using: metric, edge: edge)
     }
 }
 
 extension RopeView {
     func index(at offset: Int) -> Index {
-        Index(root.index(at: offset, in: startIndex.i..<endIndex.i, using: metric, edge: edge), alignment: metric.alignment)
+        Index(root.index(at: offset, in: btreeBounds, using: metric, edge: edge), alignment: metric.alignment)
     }
 
     subscript(offset: Int) -> Element {
@@ -1324,11 +1331,11 @@ extension RopeView {
         if i.alignment >= metric.alignment {
             return i
         }
-        return Index(root.index(roundingDown: i.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge), alignment: metric.alignment)
+        return Index(root.index(roundingDown: i.i, in: btreeBounds, using: metric, edge: edge), alignment: metric.alignment)
     }
 
     func isBoundary(_ i: Index) -> Bool {
-        root.isBoundary(i.i, in: startIndex.i..<endIndex.i, using: metric, edge: edge)
+        root.isBoundary(i.i, in: btreeBounds, using: metric, edge: edge)
     }
 }
 
@@ -1416,12 +1423,19 @@ extension Rope.UTF16View {
        bounds.upperBound
    }
 
+    private var btreeBounds: Range<BTreeNode<RopeSummary>.Index> {
+        startIndex.i.assertValid(for: base.root)
+        startIndex.i.assertValid(endIndex.i)
+        assert(startIndex.i.position <= endIndex.i.position)
+        return Range(uncheckedBounds: (startIndex.i, endIndex.i))
+    }
+
     func index(_ i: consuming Index, offsetBy distance: Int) -> Index {
-        Index(root.index(i.i, offsetBy: distance, in: startIndex.i..<endIndex.i, using: .utf16, edge: .leading), alignment: .unicodeScalar)
+        Index(root.index(i.i, offsetBy: distance, in: btreeBounds, using: .utf16, edge: .leading), alignment: .unicodeScalar)
     }
 
     func distance(from start: Index, to end: Index) -> Int {
-        root.distance(from: start.i, to: end.i, in: startIndex.i..<endIndex.i, using: .utf16, edge: .leading)
+        root.distance(from: start.i, to: end.i, in: btreeBounds, using: .utf16, edge: .leading)
     }
 }
 
@@ -1527,13 +1541,21 @@ extension Rope.LineView {
         bounds.upperBound
     }
 
+    private var btreeBounds: Range<BTreeNode<RopeSummary>.Index> {
+        startIndex.i.assertValid(for: base.root)
+        startIndex.i.assertValid(endIndex.i)
+        assert(startIndex.i.position <= endIndex.i.position)
+        return Range(uncheckedBounds: (startIndex.i, endIndex.i))
+    }
+
     var count: Int {
-        root.count(in: startIndex.i..<endIndex.i, using: .newlines) + 1
+        root.count(in: btreeBounds, using: .newlines) + 1
     }
 
     subscript(position: Index) -> Subrope {
-        if position == endIndex && isBoundary(endIndex) {
-            return Subrope(base: base, bounds: endIndex..<endIndex)
+        if position.position == endIndex.position && isBoundary(endIndex) {
+            // isBoundary will validate endIndex
+            return Subrope(base: base, bounds: Range(uncheckedBounds: (endIndex, endIndex)))
         }
 
         let start = position.alignment < .line ? index(roundingDown: position) : position
@@ -1548,29 +1570,29 @@ extension Rope.LineView {
     }
 
     func index(before i: Index) -> Index {
-        Index(root.index(before: i.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing, isKnownAligned: i.alignment >= .line), alignment: .line)
+        Index(root.index(before: i.i, in: btreeBounds, using: .newlines, edge: .trailing, isKnownAligned: i.alignment >= .line), alignment: .line)
     }
 
     func index(after i: Index) -> Index {
-        Index(root.index(after: i.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing), alignment: .line)
+        Index(root.index(after: i.i, in: btreeBounds, using: .newlines, edge: .trailing), alignment: .line)
     }
 
     func index(_ i: Index, offsetBy distance: Int) -> Index {
-        Index(root.index(i.i, offsetBy: distance, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing), alignment: .line)
+        Index(root.index(i.i, offsetBy: distance, in: btreeBounds, using: .newlines, edge: .trailing), alignment: .line)
     }
 
     func index(_ i: Index, offsetBy distance: Int, limitedBy limit: Index) -> Index? {
-        Index(root.index(i.i, offsetBy: distance, limitedBy: limit.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing, isKnownAligned: i.alignment >= .line), alignment: .line)
+        Index(root.index(i.i, offsetBy: distance, limitedBy: limit.i, in: btreeBounds, using: .newlines, edge: .trailing, isKnownAligned: i.alignment >= .line), alignment: .line)
     }
 
     func distance(from start: Index, to end: Index) -> Int {
-        root.distance(from: start.i, to: end.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing)
+        root.distance(from: start.i, to: end.i, in: btreeBounds, using: .newlines, edge: .trailing)
     }
 }
 
 extension Rope.LineView {
     func index(at offset: Int) -> Index {
-        Index(root.index(at: offset, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing), alignment: .line)
+        Index(root.index(at: offset, in: btreeBounds, using: .newlines, edge: .trailing), alignment: .line)
     }
 
     subscript(offset: Int) -> Subrope {
@@ -1581,11 +1603,11 @@ extension Rope.LineView {
         if i.alignment >= .line {
             return i
         }
-        return Index(root.index(roundingDown: i.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing), alignment: .line)
+        return Index(root.index(roundingDown: i.i, in: btreeBounds, using: .newlines, edge: .trailing), alignment: .line)
     }
 
     func isBoundary(_ i: Index) -> Bool {
-        root.isBoundary(i.i, in: startIndex.i..<endIndex.i, using: .newlines, edge: .trailing)
+        root.isBoundary(i.i, in: btreeBounds, using: .newlines, edge: .trailing)
     }
 }
 

--- a/Watt/Rope/Rope.swift
+++ b/Watt/Rope/Rope.swift
@@ -1254,7 +1254,7 @@ extension RopeView {
 // BidirectionalCollection
 extension RopeView {
     var count: Int {
-        root.count(in: startIndex.i..<endIndex.i, using: metric)
+        root.count(in: btreeBounds, using: metric)
     }
 
     var startIndex: Index {
@@ -1412,7 +1412,7 @@ extension Rope.UTF16View {
     typealias Index = Rope.Index
 
     var count: Int {
-        root.count(in: Range(uncheckedBounds: (bounds.lowerBound.i, bounds.upperBound.i)), using: .utf16)
+        root.count(in: btreeBounds, using: .utf16)
     }
 
    var startIndex: Index {

--- a/Watt/Rope/Rope.swift
+++ b/Watt/Rope/Rope.swift
@@ -1837,6 +1837,7 @@ extension Range where Bound == Rope.Index {
             j += 1
         }
 
+        assert(i <= j)
         self.init(uncheckedBounds: (rope.utf8.index(at: i), rope.utf8.index(at: j)))
     }
 

--- a/Watt/Rope/Spans.swift
+++ b/Watt/Rope/Spans.swift
@@ -591,7 +591,6 @@ extension SpansSlice: BTreeSlice {
 extension SpansSlice: BidirectionalCollection {
     typealias Index = Spans<T>.Index
 
-    // TODO: cache these on SpansSlice
     var startIndex: Index {
         if count == 0 {
             return bounds.lowerBound

--- a/Watt/Rope/Spans.swift
+++ b/Watt/Rope/Spans.swift
@@ -525,12 +525,14 @@ extension Spans {
 }
 
 struct SpansSlice<T> {
-    var base: Spans<T>
-    var bounds: Range<Index>
+    let base: Spans<T>
+    let bounds: Range<Index>
+    let count: Int
 
     init(base: Spans<T>, bounds: Range<Index>) {
         self.base = base
         self.bounds = bounds
+        self.count = base.root.count(in: bounds, using: Spans.SpansMetric())
     }
 
     var root: BTreeNode<SpansSummary<T>> {
@@ -565,10 +567,7 @@ extension SpansSlice: BTreeSlice {
 extension SpansSlice: BidirectionalCollection {
     typealias Index = Spans<T>.Index
 
-    var count: Int {
-        root.count(in: bounds, using: Spans.SpansMetric())
-    }
-
+    // TODO: cache these on SpansSlice
     var startIndex: Index {
         if count == 0 {
             return bounds.lowerBound

--- a/Watt/TextView/TextView+Layout.swift
+++ b/Watt/TextView/TextView+Layout.swift
@@ -308,8 +308,6 @@ extension TextView: LayoutManagerDelegate {
 
 extension TextView {
     func layoutTextLayer() {
-        textLayer.sublayers = nil
-
         var scrollAdjustment: CGFloat = 0
         let updateLineNumbers = lineNumberView.superview != nil
         if updateLineNumbers {
@@ -318,8 +316,9 @@ extension TextView {
 
         var lineno: Int?
 
+        var layers: [CALayer] = []
         layoutManager.layoutText { layer, prevAlignmentFrame in
-            textLayer.addSublayer(layer)
+            layers.append(layer)
 
             let oldHeight = prevAlignmentFrame.height
             let newHeight = layer.line.alignmentFrame.height
@@ -351,6 +350,8 @@ extension TextView {
                 lineno = n+1
             }
         }
+
+        textLayer.setSublayers(to: layers)
 
         if updateLineNumbers {
             lineNumberView.endUpdates()

--- a/Watt/TextView/TextView.swift
+++ b/Watt/TextView/TextView.swift
@@ -42,6 +42,7 @@ class TextView: NSView, ClipViewDelegate {
             buffer.contents.font = font
             lineNumberView.font = font
             typingAttributes.font = font
+            defaultAttributes.font = font
 
             layoutManager.invalidateLayout()
         }
@@ -58,7 +59,10 @@ class TextView: NSView, ClipViewDelegate {
 
     var foregroundColor: NSColor {
         get { theme.foregroundColor }
-        set { theme.foregroundColor = newValue }
+        set {
+            theme.foregroundColor = newValue
+            defaultAttributes.foregroundColor = newValue
+        }
     }
 
     var backgroundColor: NSColor {
@@ -81,11 +85,11 @@ class TextView: NSView, ClipViewDelegate {
         set { theme.lineNumberColor = newValue }
     }
 
-    var defaultAttributes: AttributedRope.Attributes {
+    lazy var defaultAttributes: AttributedRope.Attributes = {
         AttributedRope.Attributes
             .font(font)
             .foregroundColor(foregroundColor)
-    }
+    }()
 
     lazy var typingAttributes: AttributedRope.Attributes = defaultAttributes
 


### PR DESCRIPTION
- Improve speed of Spans/SpansSlice by getting rid of KeyPath usage and caching some data.
- Remove unnecessary index comparison and validation, e.g. when creating BTreeNode.Index ranges from Rope.Index ranges.
- TextView: Don't remove and re-add all LineLayers on each layout pass.
- LineNumberView: Don't remove and re-add all LineNumberLayers on each layout pass.
- Prevent extra copying of Leaves and Summaries in BTreeMetric implementations
- Don't reallocate defaultAttributes every time a theme gets applied to a paragraph.